### PR TITLE
feat: 커스텀 에러 핸들링 구현(#3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/develop_ping/union/common/base/AuditingFields.java
+++ b/src/main/java/com/develop_ping/union/common/base/AuditingFields.java
@@ -1,0 +1,24 @@
+package com.develop_ping.union.common.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class AuditingFields {
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private ZonedDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private ZonedDateTime updatedAt;
+}

--- a/src/main/java/com/develop_ping/union/common/error/ErrorBuildFactory.java
+++ b/src/main/java/com/develop_ping/union/common/error/ErrorBuildFactory.java
@@ -1,0 +1,36 @@
+package com.develop_ping.union.common.error;
+
+import org.springframework.validation.BindingResult;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ErrorBuildFactory {
+    public static ErrorResponse buildError(ErrorCode errorCode) {
+        return new ErrorResponse(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                errorCode.getStatus(),
+                List.of()
+        );
+    }
+    public static List<ErrorResponse.FieldError> getFieldErrors(BindingResult binding) {
+        return binding.getFieldErrors()
+                .stream()
+                .map(err -> new ErrorResponse.FieldError(
+                        err.getField(),
+                        (String) err.getRejectedValue(),
+                        err.getDefaultMessage()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    public static ErrorResponse buildFieldErrors(ErrorCode errorCode, List<ErrorResponse.FieldError> fieldErrors) {
+        return new ErrorResponse(
+                errorCode.getCode(),
+                errorCode.getCode(),
+                errorCode.getStatus(),
+                fieldErrors
+        );
+    }
+}

--- a/src/main/java/com/develop_ping/union/common/error/ErrorCode.java
+++ b/src/main/java/com/develop_ping/union/common/error/ErrorCode.java
@@ -1,0 +1,32 @@
+package com.develop_ping.union.common.error;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+    // 400 Bad Request
+    INPUT_VALUE_INVALID("INPUT_VALUE_INVALID", "데이터 형식이 맞지 않습니다.", 400),
+
+    // 401 Unauthorized
+    INVALID_TOKEN("INVALID_TOKEN", "유효하지 않은 JWT 토큰입니다.", 401),
+    INVALID_REFRESH_TOKEN("INVALID_REFRESH_TOKEN", "유효하지 않은 리프레시 토큰입니다.", 401),
+
+    // 404 Not Found
+    USER_NOT_FOUND("USER_NOT_FOUND", "해당 유저를 찾을 수 없습니다.", 404),
+    POST_NOT_FOUND("POST_NOT_FOUND", "해당 게시글을 찾을 수 없습니다.", 404),
+    GATHERING_NOT_FOUND("GATHERING_NOT_FOUND", "해당 모임을 찾을 수 없습니다.", 404),
+
+    // 409 Conflict
+    DUPLICATE_NICKNAME("DUPLICATE_NICKNAME", "이미 존재하는 닉네임입니다.", 409),
+    ;
+
+    private final String code;
+    private final String message;
+    private final Integer status;
+
+    ErrorCode(String code, String message, Integer status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/develop_ping/union/common/error/ErrorHandlingController.java
+++ b/src/main/java/com/develop_ping/union/common/error/ErrorHandlingController.java
@@ -1,0 +1,82 @@
+package com.develop_ping.union.common.error;
+
+import com.develop_ping.union.common.exception.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.List;
+
+import static com.develop_ping.union.common.error.ErrorBuildFactory.*;
+
+@Slf4j
+@RestControllerAdvice
+public class ErrorHandlingController {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("잘못된 요청 값이 전달되었습니다.");
+        List<ErrorResponse.FieldError> fieldErrors = getFieldErrors(e.getBindingResult());
+        return buildFieldErrors(ErrorCode.INPUT_VALUE_INVALID, fieldErrors);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected ErrorResponse handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("타입이 맞지 않는 요청 값입니다.");
+        ErrorResponse.FieldError fieldError = new ErrorResponse.FieldError(e.getPropertyName(), (String) e.getValue(), e.getMessage());
+        return buildFieldErrors(ErrorCode.INPUT_VALUE_INVALID, List.of(fieldError));
+    }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    protected ErrorResponse handleInvalidTokenException(InvalidTokenException e) {
+        log.error("유효하지 않은 JWT 토큰입니다.");
+        return buildError(ErrorCode.INVALID_TOKEN);
+    }
+
+    @ExceptionHandler(InvalidRefreshTokenException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorResponse handleInvalidRefreshTokenException(InvalidRefreshTokenException e) {
+        log.warn("유효하지 않은 리프레시 토큰입니다.");
+        return buildError(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    protected ErrorResponse handleUserNotFoundException(UserNotFoundException e) {
+        log.error("해당 유저를 찾을 수 없습니다.");
+        log.error("user id: {}", e.getUserId());
+        return buildError(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @ExceptionHandler(PostNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    protected ErrorResponse handlePostNotFoundException(PostNotFoundException e) {
+        log.error("해당 게시글을 찾을 수 없습니다.");
+        log.error("post id: {}", e.getPostId());
+        return buildError(ErrorCode.POST_NOT_FOUND);
+    }
+
+    @ExceptionHandler(GatheringNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    protected ErrorResponse handleGatheringNotFoundException(GatheringNotFoundException e) {
+        log.error("해당 모임을 찾을 수 없습니다.");
+        log.error("gathering id: {}", e.getGatheringId());
+        return buildError(ErrorCode.GATHERING_NOT_FOUND);
+    }
+
+    @ExceptionHandler(DuplicateNicknameException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    protected ErrorResponse handleDuplicateNicknameException(DuplicateNicknameException e) {
+        log.error("이미 존재하는 닉네임입니다.");
+        log.error("nickname: {}", e.getNickname());
+        return buildError(ErrorCode.DUPLICATE_NICKNAME);
+    }
+
+
+}

--- a/src/main/java/com/develop_ping/union/common/error/ErrorResponse.java
+++ b/src/main/java/com/develop_ping/union/common/error/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.develop_ping.union.common.error;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+public record ErrorResponse(
+        String code,
+        String message,
+        Integer status,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY) List<FieldError> errors
+) {
+    public record FieldError(String field, String value, String reason) { }
+}

--- a/src/main/java/com/develop_ping/union/common/exception/DuplicateNicknameException.java
+++ b/src/main/java/com/develop_ping/union/common/exception/DuplicateNicknameException.java
@@ -1,0 +1,12 @@
+package com.develop_ping.union.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateNicknameException extends RuntimeException {
+    private final String nickname;
+
+    public DuplicateNicknameException(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/develop_ping/union/common/exception/GatheringNotFoundException.java
+++ b/src/main/java/com/develop_ping/union/common/exception/GatheringNotFoundException.java
@@ -1,0 +1,12 @@
+package com.develop_ping.union.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class GatheringNotFoundException extends RuntimeException {
+    private final Long gatheringId;
+
+    public GatheringNotFoundException(Long gatheringId) {
+        this.gatheringId = gatheringId;
+    }
+}

--- a/src/main/java/com/develop_ping/union/common/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/develop_ping/union/common/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,4 @@
+package com.develop_ping.union.common.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException{
+}

--- a/src/main/java/com/develop_ping/union/common/exception/InvalidTokenException.java
+++ b/src/main/java/com/develop_ping/union/common/exception/InvalidTokenException.java
@@ -1,0 +1,4 @@
+package com.develop_ping.union.common.exception;
+
+public class InvalidTokenException extends RuntimeException {
+}

--- a/src/main/java/com/develop_ping/union/common/exception/PostNotFoundException.java
+++ b/src/main/java/com/develop_ping/union/common/exception/PostNotFoundException.java
@@ -1,0 +1,12 @@
+package com.develop_ping.union.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PostNotFoundException extends RuntimeException {
+    private final Long postId;
+
+    public PostNotFoundException(Long postId) {
+        this.postId = postId;
+    }
+}

--- a/src/main/java/com/develop_ping/union/common/exception/UserNotFoundException.java
+++ b/src/main/java/com/develop_ping/union/common/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package com.develop_ping.union.common.exception;
+
+import lombok.Getter;
+
+import java.security.Principal;
+
+@Getter
+public class UserNotFoundException extends RuntimeException {
+    private final Object userId;
+
+    public UserNotFoundException(Object userId) {
+        this.userId = userId;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,7 +33,6 @@ spring:
 
   datasource:
     url: jdbc:h2:mem:/uniondb
-    driver-class-name: org.h2.Driver
     username: sa
     password: password
 


### PR DESCRIPTION
새로운 에러 처리 프레임워크와 Auditing 필드를 추가했습니다.

에러 처리를 위한 새로운 클래스 추가, 에러 코드 정의, 그리고 커스텀 예외 구현이 포함되어 있습니다.
또한 생성 및 업데이트 타임스탬프를 추적하기 위한 감사 필드도 추가되었습니다.

에러 처리:

* ErrorBuildFactory 클래스를 도입하여 에러 응답과 필드 에러를 구성.
* 다양한 에러 코드와 메시지를 관리하기 위해 ErrorCode enum을 정의.
* 다양한 예외를 처리하고 적절한 에러 응답을 반환하는 ErrorHandlingController를 추가.
* ErrorResponse 레코드를 생성하여 에러 응답의 구조를 정의, 필드 에러를 중첩한 형태로 포함.


Auditing field:

* createdAt과 updatedAt 필드를 포함하는 AuditingFields 추상 클래스를 추가하여 자동 타임스탬핑을 위한 적절한 어노테이션 적용.


커스텀 예외:

* 새로운 커스텀 예외 추가 방법
1. `src/main/java/com/develop-ping/union/common/exception`에 새로운 exception class를 추가해주세요.
2. `src/main/java/com/develop-ping/union/common/error/ErrorCode.java` 양식에 맞게 추가해주세요.
3. `src/main/java/com/develop-ping/union/common/error/ErrorHandlingController.java`에 메소드를 작성합니다.



설정 변경 사항:

* [src/main/resources/application.yml](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dL36): datasource 설정에서 driver-class-name 제거.

위와 같이 커스텀 에러 처리 및 감사 필드 추가 작업이 수행되었습니다.