### PR TITLE
feat: 모임 생성 시 party 테이블에 모임 정보 추가 로직 구현 (#40)

### DIFF
--- a/src/main/java/com/develop_ping/union/gathering/domain/dto/GatheringInfo.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/dto/GatheringInfo.java
@@ -18,6 +18,7 @@ public class GatheringInfo {
     private final Double latitude;
     private final Double longitude;
     private final ZonedDateTime gatheringDateTime;
+    private final Long views;
 
     @Builder
     private GatheringInfo(
@@ -29,7 +30,8 @@ public class GatheringInfo {
         String address,
         Double latitude,
         Double longitude,
-        ZonedDateTime gatheringDateTime
+        ZonedDateTime gatheringDateTime,
+        Long views
     ) {
         this.id = id;
         this.title = title;
@@ -40,19 +42,37 @@ public class GatheringInfo {
         this.latitude = latitude;
         this.longitude = longitude;
         this.gatheringDateTime = gatheringDateTime;
+        this.views = views;
     }
 
     public static GatheringInfo of(Gathering gathering) {
         return GatheringInfo.builder()
-                .id(gathering.getId())
-                .title(gathering.getTitle())
-                .content(gathering.getContent())
-                .maxMember(gathering.getMaxMember())
-                .currentMember(gathering.getCurrentMember())
-                .address(gathering.getPlace().getAddress())
-                .latitude(gathering.getPlace().getLatitude())
-                .longitude(gathering.getPlace().getLongitude())
-                .gatheringDateTime(gathering.getGatheringDateTime())
-                .build();
+                            .id(gathering.getId())
+                            .title(gathering.getTitle())
+                            .content(gathering.getContent())
+                            .maxMember(gathering.getMaxMember())
+                            .currentMember(gathering.getCurrentMember())
+                            .address(gathering.getPlace().getAddress())
+                            .latitude(gathering.getPlace().getLatitude())
+                            .longitude(gathering.getPlace().getLongitude())
+                            .gatheringDateTime(gathering.getGatheringDateTime())
+                            .views(gathering.getViews())
+                            .build();
+    }
+
+    @Override
+    public String toString() {
+        return "GatheringInfo{" +
+            "address='" + address + '\'' +
+            ", id=" + id +
+            ", title='" + title + '\'' +
+            ", content='" + content + '\'' +
+            ", maxMember=" + maxMember +
+            ", currentMember=" + currentMember +
+            ", latitude=" + latitude +
+            ", longitude=" + longitude +
+            ", gatheringDateTime=" + gatheringDateTime +
+            ", views=" + views +
+            '}';
     }
 }

--- a/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
@@ -38,6 +38,9 @@ public class Gathering extends AuditingFields {
     @Column(name = "gathering_date_time", nullable = false)
     private ZonedDateTime gatheringDateTime;
 
+    @Column(name = "views")
+    private Long views;
+
     @Builder
     private Gathering(
         Long id,
@@ -58,6 +61,7 @@ public class Gathering extends AuditingFields {
         this.currentMember = currentMember != null ? currentMember : 1;
         this.gatheringDateTime = gatheringDateTime;
         this.place = place;
+        this.views = 0L;
     }
 
     private void validateGatheringDateTime(ZonedDateTime gatheringDateTime) {

--- a/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringService.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringService.java
@@ -5,7 +5,9 @@ import com.develop_ping.union.gathering.domain.dto.GatheringInfo;
 
 public interface GatheringService {
 
-    GatheringInfo createGathering(GatheringCommand command);
+    GatheringInfo createGathering(GatheringCommand command, Long userId);
 
     GatheringInfo getGatheringDetail(Long gatheringId);
+
+    GatheringInfo updateGathering(Long gatheringId, GatheringCommand command);
 }

--- a/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImpl.java
@@ -3,6 +3,8 @@ package com.develop_ping.union.gathering.domain.service;
 import com.develop_ping.union.gathering.domain.dto.GatheringInfo;
 import com.develop_ping.union.gathering.domain.GatheringManager;
 import com.develop_ping.union.gathering.domain.dto.GatheringCommand;
+import com.develop_ping.union.party.domain.PartyManager;
+import com.develop_ping.union.party.domain.dto.PartyInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,14 +16,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class GatheringServiceImpl implements GatheringService {
 
     private final GatheringManager gatheringManager;
+    private final PartyManager partyManager;
 
     @Transactional
-    public GatheringInfo createGathering(GatheringCommand command) {
+    public GatheringInfo createGathering(GatheringCommand command, Long userId) {
         log.info("모임 ServiceImpl 클래스 생성 : {}", command);
 
-        // TODO: party 테이블에 User정보 추가해야 됨
+        GatheringInfo savedGathering = gatheringManager.createGathering(command.toEntity());
+        PartyInfo savedParty = partyManager.createParty(savedGathering.getId(), userId);
 
-        return gatheringManager.createGathering(command.toEntity());
+        log.info("\n모임 생성 완료 로그: {}", savedGathering);
+        log.info("\n파티 생성 완료 로그: {}", savedParty);
+        return savedGathering;
     }
 
     @Override
@@ -29,5 +35,10 @@ public class GatheringServiceImpl implements GatheringService {
         log.info("모임 상세 조회 ServiceImpl 클래스 : {}", gatheringId);
 
         return gatheringManager.getGatheringDetail(gatheringId);
+    }
+
+    @Override
+    public GatheringInfo updateGathering(Long gatheringId, GatheringCommand command) {
+        return null;
     }
 }

--- a/src/main/java/com/develop_ping/union/gathering/infra/GatheringManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/gathering/infra/GatheringManagerImpl.java
@@ -25,9 +25,6 @@ public class GatheringManagerImpl implements GatheringManager {
         log.info("모임 ManagerImpl 클래스 : {}", gathering);
 
         Gathering savedGathering = gatheringRepository.save(gathering);
-
-        // TODO: party 테이블의 추가
-        // partyRepository.save(Party.builder().gathering(save).build());
         return GatheringInfo.of(savedGathering);
     }
 

--- a/src/main/java/com/develop_ping/union/gathering/presentation/GatheringController.java
+++ b/src/main/java/com/develop_ping/union/gathering/presentation/GatheringController.java
@@ -1,7 +1,7 @@
 package com.develop_ping.union.gathering.presentation;
 
-import com.develop_ping.union.gathering.domain.service.GatheringService;
 import com.develop_ping.union.gathering.domain.dto.GatheringInfo;
+import com.develop_ping.union.gathering.domain.service.GatheringService;
 import com.develop_ping.union.gathering.presentation.dto.request.GatheringRequest;
 import com.develop_ping.union.gathering.presentation.dto.response.GatheringDetailResponse;
 import com.develop_ping.union.gathering.presentation.dto.response.GatheringResponse;
@@ -29,14 +29,18 @@ public class GatheringController {
      * @return GatheringResponse
      */
     @PostMapping("/gathering")
-    public ResponseEntity<GatheringResponse> createGathering(@Valid @RequestBody GatheringRequest request) {
+    public Long createGathering(
+        @Valid @RequestBody GatheringRequest request
+    ) {
         log.info("모임 컨트롤러 진입: {}", request);
 
         // TODO: User 정보 추가해야 됨
-        GatheringInfo gathering = gatheringService.createGathering(request.toCommand());
+        Long userId = 1L;
+
+        GatheringInfo gathering = gatheringService.createGathering(request.toCommand(), userId);
         GatheringResponse response = GatheringResponse.of(gathering);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(response.getId()).getBody();
     }
 
     /**
@@ -45,7 +49,9 @@ public class GatheringController {
      * @return GatheringResponse 모임 상세 DTO
      */
     @GetMapping("/gathering/{gatheringId}")
-    public ResponseEntity<GatheringDetailResponse> getGatheringDetail(@PathVariable("gatheringId") Long gatheringId) {
+    public ResponseEntity<GatheringDetailResponse> getGatheringDetail(
+        @PathVariable("gatheringId") Long gatheringId
+    ) {
         log.info("모임 상세 조회 컨트롤러 진입: {}", gatheringId);
 
         GatheringInfo gathering = gatheringService.getGatheringDetail(gatheringId);

--- a/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringResponse.java
+++ b/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringResponse.java
@@ -19,6 +19,7 @@ public class GatheringResponse {
     private final Double latitude;
     private final Double longitude;
     private final ZonedDateTime gatheringDateTime;
+    private final Long views;
 
     @Builder
     private GatheringResponse(
@@ -30,7 +31,8 @@ public class GatheringResponse {
         String address,
         Double latitude,
         Double longitude,
-        ZonedDateTime gatheringDateTime
+        ZonedDateTime gatheringDateTime,
+        Long views
     ) {
         this.id = id;
         this.title = title;
@@ -41,19 +43,21 @@ public class GatheringResponse {
         this.latitude = latitude;
         this.longitude = longitude;
         this.gatheringDateTime = gatheringDateTime;
+        this.views = views;
     }
 
     public static GatheringResponse of(GatheringInfo gathering) {
         return GatheringResponse.builder()
-                            .id(gathering.getId())
-                            .title(gathering.getTitle())
-                            .content(gathering.getContent())
-                            .maxMember(gathering.getMaxMember())
-                            .currentMember(gathering.getCurrentMember())
-                            .address(gathering.getAddress())
-                            .latitude(gathering.getLatitude())
-                            .longitude(gathering.getLongitude())
-                            .gatheringDateTime(gathering.getGatheringDateTime())
-                            .build();
+                                .id(gathering.getId())
+                                .title(gathering.getTitle())
+                                .content(gathering.getContent())
+                                .maxMember(gathering.getMaxMember())
+                                .currentMember(gathering.getCurrentMember())
+                                .address(gathering.getAddress())
+                                .latitude(gathering.getLatitude())
+                                .longitude(gathering.getLongitude())
+                                .gatheringDateTime(gathering.getGatheringDateTime())
+                                .views(gathering.getViews())
+                                .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/party/domain/PartyManager.java
+++ b/src/main/java/com/develop_ping/union/party/domain/PartyManager.java
@@ -1,0 +1,8 @@
+package com.develop_ping.union.party.domain;
+
+import com.develop_ping.union.party.domain.dto.PartyInfo;
+
+public interface PartyManager {
+
+    PartyInfo createParty(Long gatheringId, Long userId);
+}

--- a/src/main/java/com/develop_ping/union/party/domain/dto/PartyCommand.java
+++ b/src/main/java/com/develop_ping/union/party/domain/dto/PartyCommand.java
@@ -1,0 +1,4 @@
+package com.develop_ping.union.party.domain.dto;
+
+public class PartyCommand {
+}

--- a/src/main/java/com/develop_ping/union/party/domain/dto/PartyInfo.java
+++ b/src/main/java/com/develop_ping/union/party/domain/dto/PartyInfo.java
@@ -1,0 +1,41 @@
+package com.develop_ping.union.party.domain.dto;
+
+import com.develop_ping.union.party.domain.entity.Party;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PartyInfo {
+
+    private final Long id;
+    private final Long userId;
+    private final Long gatheringId;
+    private final String role;
+
+    @Builder
+    private PartyInfo(Long id, Long userId, Long gatheringId, String role) {
+        this.id = id;
+        this.userId = userId;
+        this.gatheringId = gatheringId;
+        this.role = role;
+    }
+
+    public static PartyInfo of(Party party) {
+        return PartyInfo.builder()
+                .id(party.getId())
+                .userId(party.getUserId())
+                .gatheringId(party.getGatheringId())
+                .role(String.valueOf(party.getRole()))
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return "PartyInfo{" +
+            "gatheringId=" + gatheringId +
+            ", id=" + id +
+            ", userId=" + userId +
+            ", role='" + role + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/com/develop_ping/union/party/domain/entity/Party.java
+++ b/src/main/java/com/develop_ping/union/party/domain/entity/Party.java
@@ -1,0 +1,34 @@
+package com.develop_ping.union.party.domain.entity;
+
+import com.develop_ping.union.common.base.AuditingFields;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "parties")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Party extends AuditingFields {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private Long gatheringId;
+
+    @Enumerated(EnumType.STRING)
+    private PartyRole role;
+
+    @Builder
+    private Party(Long id, Long userId, Long gatheringId, PartyRole role) {
+        this.id = id;
+        this.userId = userId;
+        this.gatheringId = gatheringId;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/develop_ping/union/party/domain/entity/PartyRole.java
+++ b/src/main/java/com/develop_ping/union/party/domain/entity/PartyRole.java
@@ -1,0 +1,5 @@
+package com.develop_ping.union.party.domain.entity;
+
+public enum PartyRole {
+    OWNER, PARTICIPANT
+}

--- a/src/main/java/com/develop_ping/union/party/infra/PartyManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/party/infra/PartyManagerImpl.java
@@ -1,0 +1,27 @@
+package com.develop_ping.union.party.infra;
+
+import com.develop_ping.union.party.domain.PartyManager;
+import com.develop_ping.union.party.domain.dto.PartyInfo;
+import com.develop_ping.union.party.domain.entity.Party;
+import com.develop_ping.union.party.domain.entity.PartyRole;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.boot.model.naming.IllegalIdentifierException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PartyManagerImpl implements PartyManager {
+
+    private final PartyRepository partyRepository;
+
+    @Override
+    public PartyInfo createParty(Long gatheringId, Long userId) {
+
+        Party savedParty = partyRepository.save(Party.builder()
+                                                     .userId(userId)
+                                                     .gatheringId(gatheringId)
+                                                     .role(PartyRole.OWNER)
+                                                     .build());
+        return PartyInfo.of(savedParty);
+    }
+}

--- a/src/main/java/com/develop_ping/union/party/infra/PartyRepository.java
+++ b/src/main/java/com/develop_ping/union/party/infra/PartyRepository.java
@@ -1,0 +1,11 @@
+package com.develop_ping.union.party.infra;
+
+import com.develop_ping.union.party.domain.entity.Party;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PartyRepository extends JpaRepository<Party, Long> {
+
+    Optional<Party> findByGatheringIdAndUserId(Long id, Long userId);
+}

--- a/src/main/java/com/develop_ping/union/reaction/domain/entity/Reaction.java
+++ b/src/main/java/com/develop_ping/union/reaction/domain/entity/Reaction.java
@@ -1,0 +1,33 @@
+package com.develop_ping.union.reaction.domain.entity;
+
+import com.develop_ping.union.common.base.AuditingFields;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "reactions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reaction extends AuditingFields {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Long userId;
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    private ReactionType type;
+
+    @Builder
+    private Reaction(Long id, Long userId, ReactionType type) {
+        this.id = id;
+        this.userId = userId;
+        this.type = type;
+    }
+}

--- a/src/main/java/com/develop_ping/union/reaction/domain/entity/ReactionType.java
+++ b/src/main/java/com/develop_ping/union/reaction/domain/entity/ReactionType.java
@@ -1,0 +1,5 @@
+package com.develop_ping.union.reaction.domain.entity;
+
+public enum ReactionType {
+    POST, COMMENT, GATHERING
+}

--- a/src/test/java/com/develop_ping/union/IntegrationTestSupport.java
+++ b/src/test/java/com/develop_ping/union/IntegrationTestSupport.java
@@ -21,9 +21,4 @@ public abstract class IntegrationTestSupport {
 
     @MockBean
     private AmazonS3Client amazonS3Client;
-
-    @DisplayName("스프링 부트 테스트, 환경변수가 로드되어야 한다.")
-    @Test
-    void testPropertyLoad() {
-    }
 }

--- a/src/test/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImplTest.java
+++ b/src/test/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImplTest.java
@@ -1,0 +1,56 @@
+package com.develop_ping.union.gathering.domain.service;
+
+import com.develop_ping.union.IntegrationTestSupport;
+import com.develop_ping.union.gathering.domain.dto.GatheringCommand;
+import com.develop_ping.union.gathering.domain.dto.GatheringInfo;
+import com.develop_ping.union.party.domain.entity.Party;
+import com.develop_ping.union.party.domain.entity.PartyRole;
+import com.develop_ping.union.party.infra.PartyRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GatheringServiceImpl 통합 테스트")
+class GatheringServiceImplIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private GatheringServiceImpl gatheringService;
+
+    @Autowired
+    private PartyRepository partyRepository;
+
+    @DisplayName("Gathering과 Party가 정상적으로 생성된다")
+    @Test
+    void givenGatheringCommandAndUserId_whenCreateGathering_thenGatheringAndPartyAreSaved() {
+        // given
+        GatheringCommand command = GatheringCommand.builder()
+                                                   .title("모임 제목")
+                                                   .content("모임 내용")
+                                                   .maxMember(5)
+                                                   .gatheringDateTime(ZonedDateTime.now().plusHours(2))
+                                                    .address("장소")
+                                                    .latitude(37.123456)
+                                                    .longitude(127.123456)
+                                                    .build();
+        Long userId = 1L;
+
+        // when
+        GatheringInfo gatheringInfo = gatheringService.createGathering(command, userId);
+
+        // then
+        assertThat(gatheringInfo).isNotNull();
+        assertThat(gatheringInfo.getId()).isNotNull();
+        assertThat(gatheringInfo.getTitle()).isEqualTo("모임 제목");
+
+        Party savedParty = partyRepository.findByGatheringIdAndUserId(gatheringInfo.getId(), userId)
+                                          .orElse(null);
+        assertThat(savedParty).isNotNull();
+        assertThat(savedParty.getGatheringId()).isEqualTo(gatheringInfo.getId());
+        assertThat(savedParty.getUserId()).isEqualTo(userId);
+        assertThat(savedParty.getRole()).isEqualTo(PartyRole.OWNER);
+    }
+}

--- a/src/test/java/com/develop_ping/union/party/infra/PartyRepositoryTest.java
+++ b/src/test/java/com/develop_ping/union/party/infra/PartyRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.develop_ping.union.party.infra;
+
+import com.develop_ping.union.IntegrationTestSupport;
+import com.develop_ping.union.party.domain.entity.Party;
+import com.develop_ping.union.party.domain.entity.PartyRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("PartyRepository 테스트")
+@Transactional
+class PartyRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private PartyRepository partyRepository;
+
+    @DisplayName("Party 엔티티를 저장하고 조회할 수 있다")
+    @Test
+    void Party_엔티티를_저장하고_조회할_수_있다() {
+        // given
+        Long gatheringId = 1L;
+        Long userId = 1L;
+        PartyRole role = PartyRole.OWNER;
+
+        Party party = Party.builder()
+                           .gatheringId(gatheringId)
+                           .userId(userId)
+                           .role(role)
+                           .build();
+
+        // when
+        Party savedParty = partyRepository.save(party);
+
+        // then
+        assertThat(savedParty).isNotNull();
+        assertThat(savedParty.getGatheringId()).isEqualTo(gatheringId);
+        assertThat(savedParty.getUserId()).isEqualTo(userId);
+        assertThat(savedParty.getRole()).isEqualTo(role);
+    }
+
+    @DisplayName("GatheringId와 UserId로 Party를 조회할 수 있다")
+    @Test
+    void GatheringId와_UserId로_Party를_조회할_수_있다() {
+        // given
+        Long gatheringId = 1L;
+        Long userId = 1L;
+        Party party = Party.builder()
+                           .gatheringId(gatheringId)
+                           .userId(userId)
+                           .role(PartyRole.OWNER)
+                           .build();
+        partyRepository.save(party);
+
+        // when
+        Party foundParty = partyRepository.findByGatheringIdAndUserId(gatheringId, userId)
+                                          .orElse(null);
+
+        // then
+        assertThat(foundParty).isNotNull();
+        assertThat(foundParty.getGatheringId()).isEqualTo(gatheringId);
+        assertThat(foundParty.getUserId()).isEqualTo(userId);
+    }
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #40 

## 📝 작업 내용
- party 테이블 추가
- 모임 생성 시 party 테이블에 모임과 관련된 정보 추가
- 생성한 유저가 owner

## 🎸 기타 (선택)
없음

## 💬 리뷰 요구사항(선택)
없음
