### PR TITLE
Feat/#71 reply comment

### DIFF
--- a/src/main/java/com/develop_ping/union/comment/domain/CommentManager.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/CommentManager.java
@@ -8,5 +8,5 @@ public interface CommentManager {
     Comment save(Comment comment);
     Comment findById(Long id);
     void delete(Comment comment);
-    List<Comment> findByPostId(Long postId);
+    List<Comment> findByPostIdAndParentIsNull(Long postId);
 }

--- a/src/main/java/com/develop_ping/union/comment/domain/CommentManager.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/CommentManager.java
@@ -2,8 +2,11 @@ package com.develop_ping.union.comment.domain;
 
 import com.develop_ping.union.comment.domain.entity.Comment;
 
+import java.util.List;
+
 public interface CommentManager {
     Comment save(Comment comment);
     Comment findById(Long id);
     void delete(Comment comment);
+    List<Comment> findByPostId(Long postId);
 }

--- a/src/main/java/com/develop_ping/union/comment/domain/dto/CommentCommand.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/dto/CommentCommand.java
@@ -1,10 +1,7 @@
 package com.develop_ping.union.comment.domain.dto;
 
 import com.develop_ping.union.user.domain.entity.User;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -14,14 +11,21 @@ public class CommentCommand {
     private Long postId;
     private User user;
     private Long parentId;
+    private String parentNickname;
 
     @Builder
-    public CommentCommand(Long id, String content, Long postId, User user, Long parentId) {
+    public CommentCommand(Long id,
+                          String content,
+                          Long postId,
+                          User user,
+                          Long parentId,
+                          String parentNickname) {
         this.id = id;
         this.content = content;
         this.postId = postId;
         this.user = user;
         this.parentId = parentId;
+        this.parentNickname = parentNickname;
     }
 
     public static CommentCommand deletionOf(Long id, User user) {

--- a/src/main/java/com/develop_ping/union/comment/domain/dto/CommentInfo.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/dto/CommentInfo.java
@@ -16,40 +16,53 @@ public class CommentInfo {
     private String content;
     private Long postId;
     private Long parentId;
+    private String parentNickname;
     private ZonedDateTime createdAt;
     private String nickname;
     private String profileImage;
     private String univName;
+    private List<CommentInfo> children;
 
     @Builder
     private CommentInfo(Long id,
                         String content,
                         Long postId,
                         Long parentId,
+                        String parentNickname,
                         ZonedDateTime createdAt,
                         String nickname,
                         String profileImage,
-                        String univName) {
+                        String univName,
+                        List<CommentInfo> children) {
         this.id = id;
         this.content = content;
         this.postId = postId;
         this.parentId = parentId;
+        this.parentNickname = parentNickname;
         this.createdAt = createdAt;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.univName = univName;
+        this.children = children;
     }
 
     public static CommentInfo of(Comment comment) {
-        return CommentInfo.builder()
+        CommentInfo.CommentInfoBuilder builder = CommentInfo.builder()
                 .id(comment.getId())
                 .content(comment.getContent())
                 .postId(comment.getPost().getId())
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+                .parentNickname(comment.getParent() != null ? comment.getParent().getUser().getNickname() : null)
                 .createdAt(comment.getCreatedAt())
                 .nickname(comment.getUser().getNickname())
                 .profileImage(comment.getUser().getProfileImage())
-                .univName(comment.getUser().getUnivName())
-                .build();
+                .univName(comment.getUser().getUnivName());
+
+        // 모든 댓글에 대해 자식 리스트를 설정
+        List<Comment> childComments = comment.getChildren();
+        builder.children(childComments.isEmpty() ? List.of() :
+                childComments.stream().map(CommentInfo::of).toList());
+
+        return builder.build();
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/domain/dto/CommentInfo.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/dto/CommentInfo.java
@@ -18,6 +18,7 @@ public class CommentInfo {
     private Long parentId;
     private String parentNickname;
     private ZonedDateTime createdAt;
+    private String token;
     private String nickname;
     private String profileImage;
     private String univName;
@@ -30,6 +31,7 @@ public class CommentInfo {
                         Long parentId,
                         String parentNickname,
                         ZonedDateTime createdAt,
+                        String token,
                         String nickname,
                         String profileImage,
                         String univName,
@@ -40,6 +42,7 @@ public class CommentInfo {
         this.parentId = parentId;
         this.parentNickname = parentNickname;
         this.createdAt = createdAt;
+        this.token = token;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.univName = univName;
@@ -52,8 +55,9 @@ public class CommentInfo {
                 .content(comment.getContent())
                 .postId(comment.getPost().getId())
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
-                .parentNickname(comment.getParent() != null ? comment.getParent().getUser().getNickname() : null)
+                .parentNickname(comment.getParentNickname() != null ? comment.getParentNickname() : null)
                 .createdAt(comment.getCreatedAt())
+                .token(comment.getUser().getToken())
                 .nickname(comment.getUser().getNickname())
                 .profileImage(comment.getUser().getProfileImage())
                 .univName(comment.getUser().getUnivName());

--- a/src/main/java/com/develop_ping/union/comment/domain/dto/CommentListInfo.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/dto/CommentListInfo.java
@@ -6,24 +6,43 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentListInfo {
+    // TODO: 기존 로직 다 지우고 comment list info는 최상위 댓글만 가지고 있게 변경하기
     private List<CommentInfo> comments;
 
     @Builder
-    public CommentListInfo(List<Comment> comments) {
-        this.comments = comments.stream()
-                .map(CommentInfo::of)
-                .collect(Collectors.toList());
+    private CommentListInfo(List<CommentInfo> comments) {
+        this.comments = comments;
     }
 
     public static CommentListInfo of(List<Comment> comments) {
+        // 모든 댓글을 CommentInfo 객체로 변환하고 ID를 기준으로 Map에 저장
+        Map<Long, CommentInfo> commentInfoMap = comments.stream()
+                .map(CommentInfo::of)
+                .collect(Collectors.toMap(CommentInfo::getId, info -> info));
+
+        // 각 댓글의 부모를 찾아서 children 리스트에 추가하여 트리 구조를 구성
+        List<CommentInfo> topComments = new ArrayList<>();
+        for (CommentInfo info : commentInfoMap.values()) {
+            if (info.getParentId() == null) {
+                topComments.add(info); // 최상위 댓글은 루트 리스트에 추가
+            } else {
+                CommentInfo parentInfo = commentInfoMap.get(info.getParentId());
+                if (parentInfo != null) {
+                    parentInfo.getChildren().add(info); // 부모의 children에 info 추가
+                }
+            }
+        }
+
         return CommentListInfo.builder()
-                .comments(comments)
+                .comments(topComments)
                 .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/domain/dto/CommentListInfo.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/dto/CommentListInfo.java
@@ -6,15 +6,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentListInfo {
-    // TODO: 기존 로직 다 지우고 comment list info는 최상위 댓글만 가지고 있게 변경하기
     private List<CommentInfo> comments;
 
     @Builder
@@ -22,27 +19,13 @@ public class CommentListInfo {
         this.comments = comments;
     }
 
-    public static CommentListInfo of(List<Comment> comments) {
-        // 모든 댓글을 CommentInfo 객체로 변환하고 ID를 기준으로 Map에 저장
-        Map<Long, CommentInfo> commentInfoMap = comments.stream()
+    public static CommentListInfo of(List<Comment> rootComments) {
+        List<CommentInfo> commentInfos = rootComments.stream()
                 .map(CommentInfo::of)
-                .collect(Collectors.toMap(CommentInfo::getId, info -> info));
-
-        // 각 댓글의 부모를 찾아서 children 리스트에 추가하여 트리 구조를 구성
-        List<CommentInfo> topComments = new ArrayList<>();
-        for (CommentInfo info : commentInfoMap.values()) {
-            if (info.getParentId() == null) {
-                topComments.add(info); // 최상위 댓글은 루트 리스트에 추가
-            } else {
-                CommentInfo parentInfo = commentInfoMap.get(info.getParentId());
-                if (parentInfo != null) {
-                    parentInfo.getChildren().add(info); // 부모의 children에 info 추가
-                }
-            }
-        }
+                .collect(Collectors.toList());
 
         return CommentListInfo.builder()
-                .comments(topComments)
+                .comments(commentInfos)
                 .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/domain/dto/CommentListInfo.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/dto/CommentListInfo.java
@@ -1,0 +1,29 @@
+package com.develop_ping.union.comment.domain.dto;
+
+import com.develop_ping.union.comment.domain.entity.Comment;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentListInfo {
+    private List<CommentInfo> comments;
+
+    @Builder
+    public CommentListInfo(List<Comment> comments) {
+        this.comments = comments.stream()
+                .map(CommentInfo::of)
+                .collect(Collectors.toList());
+    }
+
+    public static CommentListInfo of(List<Comment> comments) {
+        return CommentListInfo.builder()
+                .comments(comments)
+                .build();
+    }
+}

--- a/src/main/java/com/develop_ping/union/comment/domain/entity/Comment.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/entity/Comment.java
@@ -1,6 +1,5 @@
 package com.develop_ping.union.comment.domain.entity;
 
-import com.develop_ping.union.comment.domain.dto.CommentCommand;
 import com.develop_ping.union.common.base.AuditingFields;
 import com.develop_ping.union.post.domain.entity.Post;
 import com.develop_ping.union.user.domain.entity.User;
@@ -43,7 +42,7 @@ public class Comment extends AuditingFields {
     @Column(nullable = true)
     private String parentNickname;
 
-    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY) // 부모 댓글 삭제되어도 유지
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL) // 지금은 부모 댓글 삭제되면 전체 삭제하기
     private List<Comment> children = new ArrayList<>();
 
     @Builder
@@ -75,9 +74,5 @@ public class Comment extends AuditingFields {
 
     public void updateContent(String content) {
         this.content = content;
-    }
-
-    public void addChildComment(Comment comment) {
-        this.children.add(comment);
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/domain/entity/Comment.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/entity/Comment.java
@@ -19,6 +19,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "comments")
 public class Comment extends AuditingFields {
+    // TODO: deletedAt 필드 추가해서 삭제된 댓글 표시하기
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -38,6 +40,9 @@ public class Comment extends AuditingFields {
     @JsonIgnore // 순환 참조 방지
     private Comment parent;
 
+    @Column(nullable = true)
+    private String parentNickname;
+
     @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY) // 부모 댓글 삭제되어도 유지
     private List<Comment> children = new ArrayList<>();
 
@@ -45,19 +50,26 @@ public class Comment extends AuditingFields {
     private Comment(String content,
                     Post post,
                     User user,
-                    Comment parent) {
+                    Comment parent,
+                    String parentNickname) {
         this.content = content;
         this.post = post;
         this.user = user;
         this.parent = parent;
+        this.parentNickname = parentNickname;
     }
 
-    public static Comment of(String content, Post post, User user, Comment parent) {
+    public static Comment of(String content,
+                             Post post,
+                             User user,
+                             Comment parent,
+                             String parentNickname) {
         return Comment.builder()
                 .content(content)
                 .post(post)
                 .user(user)
                 .parent(parent)
+                .parentNickname(parentNickname)
                 .build();
     }
 

--- a/src/main/java/com/develop_ping/union/comment/domain/service/CommentService.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/service/CommentService.java
@@ -1,8 +1,6 @@
 package com.develop_ping.union.comment.domain.service;
 
-import com.develop_ping.union.comment.domain.dto.CommentCommand;
-import com.develop_ping.union.comment.domain.dto.CommentInfo;
-import com.develop_ping.union.comment.domain.dto.CommentListInfo;
+import com.develop_ping.union.comment.domain.dto.*;
 
 public interface CommentService {
     CommentInfo createComment(CommentCommand command);

--- a/src/main/java/com/develop_ping/union/comment/domain/service/CommentService.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/service/CommentService.java
@@ -2,10 +2,12 @@ package com.develop_ping.union.comment.domain.service;
 
 import com.develop_ping.union.comment.domain.dto.CommentCommand;
 import com.develop_ping.union.comment.domain.dto.CommentInfo;
+import com.develop_ping.union.comment.domain.dto.CommentListInfo;
 
 public interface CommentService {
     CommentInfo createComment(CommentCommand command);
     CommentInfo getComment(Long commentId);
     CommentInfo updateComment(CommentCommand command);
     void deleteComment(CommentCommand command);
+    CommentListInfo getCommentsByPostId(Long postId);
 }

--- a/src/main/java/com/develop_ping/union/comment/domain/service/CommentServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/service/CommentServiceImpl.java
@@ -1,9 +1,7 @@
 package com.develop_ping.union.comment.domain.service;
 
 import com.develop_ping.union.comment.domain.CommentManager;
-import com.develop_ping.union.comment.domain.dto.CommentCommand;
-import com.develop_ping.union.comment.domain.dto.CommentInfo;
-import com.develop_ping.union.comment.domain.dto.CommentListInfo;
+import com.develop_ping.union.comment.domain.dto.*;
 import com.develop_ping.union.comment.domain.entity.Comment;
 import com.develop_ping.union.comment.exception.CommentPermissionDeniedException;
 import com.develop_ping.union.comment.exception.CommenterMismatchException;
@@ -13,6 +11,7 @@ import com.develop_ping.union.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -24,6 +23,7 @@ public class CommentServiceImpl implements CommentService {
     private final PostManager postManager;
 
     @Override
+    @Transactional
     public CommentInfo createComment(CommentCommand command) {
         log.info("[ CommentService.createComment() ] user id: {}", command.getUser().getId());
 
@@ -33,6 +33,7 @@ public class CommentServiceImpl implements CommentService {
 
         Comment comment = commentManager.save(Comment.of(command.getContent(), post, user, parent, command.getParentNickname()));
 
+        log.info("[ New Comment! ] comment id: {}", comment.getId());
         return CommentInfo.of(comment);
     }
 
@@ -46,6 +47,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
+    @Transactional
     public CommentInfo updateComment(CommentCommand command) {
         log.info("[ CommentService.updateComment() ] comment id: {}", command.getId());
 
@@ -57,10 +59,13 @@ public class CommentServiceImpl implements CommentService {
         comment.updateContent(command.getContent());
 
         Comment updatedComment = commentManager.save(comment);
+
+        log.info("[ Updated Comment! ] comment id: {}", updatedComment.getId());
         return CommentInfo.of(updatedComment);
     }
 
     @Override
+    @Transactional
     public void deleteComment(CommentCommand command) {
         log.info("[ CommentService.deleteComment() ] comment id: {}", command.getId());
 
@@ -69,37 +74,41 @@ public class CommentServiceImpl implements CommentService {
 
         validateCommentOwner(user, comment);
         commentManager.delete(comment);
+        log.info("[ Deleted Comment! ] comment id: {}", comment.getId());
     }
 
     @Override
+    @Transactional(readOnly = true)
     public CommentListInfo getCommentsByPostId(Long postId) {
         log.info("[ CommentService.getCommentsByPostId() ] post id: {}", postId);
 
         Post post = postManager.findById(postId);
         List<Comment> rootComments = commentManager.findByPostIdAndParentIsNull(post.getId());
 
+        log.info("[ Found Comments! ]");
         return CommentListInfo.of(rootComments);
     }
 
     private void validateCommentOwner(User user, Comment comment) {
+        log.info("[ validateCommentOwner() ]");
         if (!user.getId().equals(comment.getUser().getId())) {
             throw new CommentPermissionDeniedException(user.getId(), comment.getId());
         }
     }
 
     private Comment getValidatedParent(Long parentId, String parentNickname) {
-        Comment parent = null;
-        if (parentId != null) {
-            parent = commentManager.findById(parentId);
-            validateParentNickname(parent.getUser(), parentNickname);
+        log.info("[ getValidatedParent() ]");
+        if (parentId == null) return null;
 
-            // 부모 댓글이 최상위 댓글인지 확인하여 반환
-            return parent.getParent() != null ? parent.getParent() : parent;
-        }
-        return parent;
+        Comment parent = commentManager.findById(parentId);
+        validateParentNickname(parent.getUser(), parentNickname);
+
+        // 부모 댓글이 최상위 댓글인지 확인하여 반환
+        return parent.getParent() != null ? parent.getParent() : parent;
     }
 
     private void validateParentNickname(User user, String parentNickname) {
+        log.info("[ validateParentNickname() ]");
         if (!user.getNickname().equals(parentNickname)) {
             throw new CommenterMismatchException(parentNickname);
         }

--- a/src/main/java/com/develop_ping/union/comment/domain/service/CommentServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/service/CommentServiceImpl.java
@@ -3,6 +3,7 @@ package com.develop_ping.union.comment.domain.service;
 import com.develop_ping.union.comment.domain.CommentManager;
 import com.develop_ping.union.comment.domain.dto.CommentCommand;
 import com.develop_ping.union.comment.domain.dto.CommentInfo;
+import com.develop_ping.union.comment.domain.dto.CommentListInfo;
 import com.develop_ping.union.comment.domain.entity.Comment;
 import com.develop_ping.union.comment.exception.CommentPermissionDeniedException;
 import com.develop_ping.union.post.domain.PostManager;
@@ -11,6 +12,8 @@ import com.develop_ping.union.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @Slf4j
@@ -69,6 +72,15 @@ public class CommentServiceImpl implements CommentService {
 
         validateCommentOwner(user, comment);
         commentManager.delete(comment);
+    }
+
+    @Override
+    public CommentListInfo getCommentsByPostId(Long postId) {
+        log.info("[ CommentService.getCommentsByPostId() ] post id: {}", postId);
+
+        List<Comment> comments = commentManager.findByPostId(postId);
+
+        return CommentListInfo.of(comments);
     }
 
     private void validateCommentOwner(User user, Comment comment) {

--- a/src/main/java/com/develop_ping/union/comment/exception/CommenterMismatchException.java
+++ b/src/main/java/com/develop_ping/union/comment/exception/CommenterMismatchException.java
@@ -1,0 +1,12 @@
+package com.develop_ping.union.comment.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CommenterMismatchException extends RuntimeException {
+    private final String nickname;
+
+    public CommenterMismatchException(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/develop_ping/union/comment/infra/CommentManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/comment/infra/CommentManagerImpl.java
@@ -6,6 +6,8 @@ import com.develop_ping.union.comment.exception.CommentNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class CommentManagerImpl implements CommentManager {
@@ -25,5 +27,10 @@ public class CommentManagerImpl implements CommentManager {
     @Override
     public void delete(Comment comment) {
         commentRepository.delete(comment);
+    }
+
+    @Override
+    public List<Comment> findByPostId(Long postId) {
+        return commentRepository.findByPostId(postId);
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/infra/CommentManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/comment/infra/CommentManagerImpl.java
@@ -5,6 +5,7 @@ import com.develop_ping.union.comment.domain.entity.Comment;
 import com.develop_ping.union.comment.exception.CommentNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -14,6 +15,7 @@ public class CommentManagerImpl implements CommentManager {
     private final CommentRepository commentRepository;
 
     @Override
+    @Transactional
     public Comment save(Comment comment) {
         return commentRepository.save(comment);
     }
@@ -25,6 +27,7 @@ public class CommentManagerImpl implements CommentManager {
     }
 
     @Override
+    @Transactional
     public void delete(Comment comment) {
         commentRepository.delete(comment);
     }

--- a/src/main/java/com/develop_ping/union/comment/infra/CommentManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/comment/infra/CommentManagerImpl.java
@@ -30,7 +30,7 @@ public class CommentManagerImpl implements CommentManager {
     }
 
     @Override
-    public List<Comment> findByPostId(Long postId) {
-        return commentRepository.findByPostId(postId);
+    public List<Comment> findByPostIdAndParentIsNull(Long postId) {
+        return commentRepository.findByPostIdAndParentIsNull(postId);
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/infra/CommentRepository.java
+++ b/src/main/java/com/develop_ping/union/comment/infra/CommentRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findByPostId(Long postId);
+    List<Comment> findByPostIdAndParentIsNull(Long postId);
 }

--- a/src/main/java/com/develop_ping/union/comment/infra/CommentRepository.java
+++ b/src/main/java/com/develop_ping/union/comment/infra/CommentRepository.java
@@ -4,6 +4,9 @@ import com.develop_ping.union.comment.domain.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByPostId(Long postId);
 }

--- a/src/main/java/com/develop_ping/union/comment/presentation/CommentController.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/CommentController.java
@@ -61,4 +61,14 @@ public class CommentController {
 
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/comments/{postId}")
+    public ResponseEntity<CommentListResponse> getCommentsByPostId(@PathVariable("postId") Long postId) {
+        log.info("[ CALL: CommentController.getCommentsByPostId() ] with postId: {}", postId);
+
+        CommentListInfo listInfo = commentService.getCommentsByPostId(postId);
+        CommentListResponse response = CommentListResponse.from(listInfo);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/develop_ping/union/comment/presentation/CommentController.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/CommentController.java
@@ -66,6 +66,7 @@ public class CommentController {
     public ResponseEntity<CommentListResponse> getCommentsByPostId(@PathVariable("postId") Long postId) {
         log.info("[ CALL: CommentController.getCommentsByPostId() ] with postId: {}", postId);
 
+        // TODO: info와 response의 변경 스펙에 따라 수정하기
         CommentListInfo listInfo = commentService.getCommentsByPostId(postId);
         CommentListResponse response = CommentListResponse.from(listInfo);
 

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/request/CommentCreationRequest.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/request/CommentCreationRequest.java
@@ -20,12 +20,15 @@ public class CommentCreationRequest {
 
     private Long parentId;
 
+    private String parentNickname;
+
     public CommentCommand toCommand(User user) {
         return CommentCommand.builder()
                 .content(this.content)
                 .postId(this.postId)
                 .user(user)
                 .parentId(this.parentId)
+                .parentNickname(this.parentNickname)
                 .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentDetailResponse.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentDetailResponse.java
@@ -11,55 +11,38 @@ import java.time.ZonedDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentDetailResponse {
-    private CommentResponse comment;
+    private Long id;
+    private String content;
+    private Long postId;
+    private Long parentId;
+    private ZonedDateTime createdAt;
     private CommenterResponse commenter;
 
     @Builder
-    public CommentDetailResponse(CommentResponse comment, CommenterResponse commenter) {
-        this.comment = comment;
+    public CommentDetailResponse(Long id,
+                                 String content,
+                                 Long postId,
+                                 Long parentId,
+                                 ZonedDateTime createdAt,
+                                 CommenterResponse commenter) {
+        this.id = id;
+        this.content = content;
+        this.postId = postId;
+        this.parentId = parentId;
+        this.createdAt = createdAt;
         this.commenter = commenter;
     }
 
     public static CommentDetailResponse from(CommentInfo info) {
         return CommentDetailResponse.builder()
-                .comment(CommentResponse.from(info))
+                .id(info.getId())
+                .content(info.getContent())
+                .postId(info.getPostId())
+                .parentId(info.getParentId())
+                .createdAt(info.getCreatedAt())
                 .commenter(CommenterResponse.from(info))
                 .build();
     }
-
-    @Getter
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class CommentResponse {
-        private Long id;
-        private String content;
-        private Long postId;
-        private Long parentId;
-        private ZonedDateTime createdAt;
-
-        @Builder
-        private CommentResponse(Long id,
-                               String content,
-                               Long postId,
-                               Long parentId,
-                               ZonedDateTime createdAt) {
-            this.id = id;
-            this.content = content;
-            this.postId = postId;
-            this.parentId = parentId;
-            this.createdAt = createdAt;
-        }
-
-        public static CommentResponse from(CommentInfo info) {
-            return CommentResponse.builder()
-                    .id(info.getId())
-                    .content(info.getContent())
-                    .postId(info.getPostId())
-                    .parentId(info.getParentId())
-                    .createdAt(info.getCreatedAt())
-                    .build();
-        }
-    }
-
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentDetailResponse.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentDetailResponse.java
@@ -60,14 +60,17 @@ public class CommentDetailResponse {
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class CommenterResponse {
+        private String token;
         private String nickname;
         private String profileImage;
         private String univName;
 
         @Builder
-        private CommenterResponse(String nickname,
+        private CommenterResponse(String token,
+                                  String nickname,
                                   String profileImage,
                                   String univName) {
+            this.token = token;
             this.nickname = nickname;
             this.profileImage = profileImage;
             this.univName = univName;
@@ -75,6 +78,7 @@ public class CommentDetailResponse {
 
         public static CommenterResponse from(CommentInfo info) {
             return CommenterResponse.builder()
+                    .token(info.getToken())
                     .nickname(info.getNickname())
                     .profileImage(info.getProfileImage())
                     .univName(info.getUnivName())

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentDetailResponse.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentDetailResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,32 +16,44 @@ public class CommentDetailResponse {
     private String content;
     private Long postId;
     private Long parentId;
+    private String parentNickname;
     private ZonedDateTime createdAt;
     private CommenterResponse commenter;
+    private List<CommentDetailResponse> children;
 
     @Builder
     public CommentDetailResponse(Long id,
                                  String content,
                                  Long postId,
                                  Long parentId,
+                                 String parentNickname,
                                  ZonedDateTime createdAt,
-                                 CommenterResponse commenter) {
+                                 CommenterResponse commenter,
+                                 List<CommentDetailResponse> children) {
         this.id = id;
         this.content = content;
         this.postId = postId;
         this.parentId = parentId;
+        this.parentNickname = parentNickname;
         this.createdAt = createdAt;
         this.commenter = commenter;
+        this.children = children;
     }
 
     public static CommentDetailResponse from(CommentInfo info) {
+        List<CommentDetailResponse> childResponse = info.getChildren().stream()
+                .map(CommentDetailResponse::from)
+                .toList();
+
         return CommentDetailResponse.builder()
                 .id(info.getId())
                 .content(info.getContent())
                 .postId(info.getPostId())
                 .parentId(info.getParentId())
+                .parentNickname(info.getParentNickname())
                 .createdAt(info.getCreatedAt())
                 .commenter(CommenterResponse.from(info))
+                .children(childResponse)
                 .build();
     }
 
@@ -53,8 +66,8 @@ public class CommentDetailResponse {
 
         @Builder
         private CommenterResponse(String nickname,
-                                 String profileImage,
-                                 String univName) {
+                                  String profileImage,
+                                  String univName) {
             this.nickname = nickname;
             this.profileImage = profileImage;
             this.univName = univName;

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentListResponse.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentListResponse.java
@@ -12,10 +12,11 @@ import java.util.stream.Collectors;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentListResponse {
+    // TODO: 기존 로직 다 지우고 가지고 온 최상위 댓글의 자식 댓글들 depth 수정하기
     private List<CommentDetailResponse> comments;
 
     @Builder
-    public CommentListResponse(List<CommentDetailResponse> comments) {
+    private CommentListResponse(List<CommentDetailResponse> comments) {
         this.comments = comments;
     }
 

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentListResponse.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentListResponse.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentListResponse {
-    // TODO: 기존 로직 다 지우고 가지고 온 최상위 댓글의 자식 댓글들 depth 수정하기
     private List<CommentDetailResponse> comments;
 
     @Builder

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentListResponse.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentListResponse.java
@@ -1,0 +1,31 @@
+package com.develop_ping.union.comment.presentation.dto.response;
+
+import com.develop_ping.union.comment.domain.dto.CommentListInfo;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentListResponse {
+    private List<CommentDetailResponse> comments;
+
+    @Builder
+    public CommentListResponse(List<CommentDetailResponse> comments) {
+        this.comments = comments;
+    }
+
+    public static CommentListResponse from(CommentListInfo listInfo) {
+        List<CommentDetailResponse> responseList = listInfo.getComments().stream()
+                .map(CommentDetailResponse::from)
+                .collect(Collectors.toList());
+
+        return CommentListResponse.builder()
+                .comments(responseList)
+                .build();
+    }
+}

--- a/src/main/java/com/develop_ping/union/common/error/ErrorCode.java
+++ b/src/main/java/com/develop_ping/union/common/error/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
     INPUT_VALUE_INVALID("INPUT_VALUE_INVALID", "데이터 형식이 맞지 않습니다.", 400),
     UNSUPPORTED_FILE_FORMAT("UNSUPPORTED_FILE_FORMAT", "지원하지 않는 파일 형식입니다.", 400),
     INVALID_S3_URL("INVALID_S3_URL", "등록되지 않은 이미지 URL이 전달되었습니다.", 400),
+    COMMENTER_MISMATCH("COMMENTER_MISMATCH", "댓글 작성자가 일치하지 않습니다.", 400),
 
     // 401 Unauthorized
     INVALID_TOKEN("INVALID_TOKEN", "유효하지 않은 JWT 토큰입니다.", 401),

--- a/src/main/java/com/develop_ping/union/common/error/ErrorHandlingController.java
+++ b/src/main/java/com/develop_ping/union/common/error/ErrorHandlingController.java
@@ -156,4 +156,12 @@ public class ErrorHandlingController {
         log.error("조회한 user id: {}, 차단한 user id: {}", e.getBlockedUserName(), e.getBlockingUserName());
         return buildError(ErrorCode.BLOCK_RELATIONSHIP_NOT_FOUND);
     }
+
+    @ExceptionHandler(CommenterMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected ErrorResponse handleCommenterMismatchException(CommenterMismatchException e) {
+        log.error("댓글 작성자가 일치하지 않습니다.");
+        log.error("commenter nickname: {}", e.getNickname());
+        return buildError(ErrorCode.COMMENTER_MISMATCH);
+    }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈

> close #71

## 📝 작업 내용

> 부모-자식 관계 댓글 목록 생성
> children의 최대 depth = 1

> 댓글 생성 시 request body에 부모 댓글 작성자 정보(닉네임) 추가됨
> 엔티티에도 parentNickname 필드 추가됨

> 댓글 작성자 정보에 user token 추가됨

## 🎸 기타 (선택)
> TODO: deletedAt 필드 추가해서 댓글 삭제 관리하기
> 부모 댓글이 삭제되어도 자식 댓글은 남아있음

## 💬 리뷰 요구사항(선택)

> 
