### PR TITLE
feat: 모임 가입 API (#86)

### DIFF
--- a/src/main/java/com/develop_ping/union/common/error/ErrorCode.java
+++ b/src/main/java/com/develop_ping/union/common/error/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
 
     // 409 Conflict
     DUPLICATE_NICKNAME("DUPLICATE_NICKNAME", "이미 존재하는 닉네임입니다.", 409),
+    ALREADY_JOINED("ALREADY_JOINED", "이미 가입되었습니다.", 409),
+    PARTICIPANT_LIMIT_EXCEEDED("PARTICIPANT_LIMIT_EXCEEDED", "정원이 가득 찼습니다.", 409),
 
     // 422 Unprocessable Entity
     IMAGE_UPLOAD_FAILED("IMAGE_UPLOAD_FAILED", "이미지 업로드에 실패하였습니다.", 422),

--- a/src/main/java/com/develop_ping/union/common/error/ErrorHandlingController.java
+++ b/src/main/java/com/develop_ping/union/common/error/ErrorHandlingController.java
@@ -6,6 +6,8 @@ import com.develop_ping.union.auth.exception.OauthNotPreparedException;
 import com.develop_ping.union.comment.exception.CommentNotFoundException;
 import com.develop_ping.union.comment.exception.CommentPermissionDeniedException;
 import com.develop_ping.union.comment.exception.CommenterMismatchException;
+import com.develop_ping.union.gathering.exception.ParticipantLimitExceededException;
+import com.develop_ping.union.party.exception.AlreadyJoinedException;
 import com.develop_ping.union.gathering.exception.GatheringNotFoundException;
 import com.develop_ping.union.gathering.exception.GatheringPermissionDeniedException;
 import com.develop_ping.union.gathering.exception.GatheringValidationException;
@@ -181,5 +183,21 @@ public class ErrorHandlingController {
         log.error("해당 모임에 대한 권한이 없습니다.");
         log.error("user id: {}, owner id: {}", e.getUserId(), e.getOwnerId());
         return buildError(ErrorCode.GATHERING_PERMISSION_DENIED);
+    }
+
+    @ExceptionHandler(AlreadyJoinedException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    protected ErrorResponse handleAlreadyJoinedException(AlreadyJoinedException e) {
+        log.error("이미 참가한 모임입니다.");
+        log.error("gathering id: {}", e.getMessage());
+        return buildError(ErrorCode.ALREADY_JOINED);
+    }
+
+    @ExceptionHandler(ParticipantLimitExceededException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    protected ErrorResponse handleParticipantLimitExceededException(ParticipantLimitExceededException e) {
+        log.error("모임 인원이 가득 찼습니다.");
+        log.error("message: {}", e.getMessage());
+        return buildError(ErrorCode.PARTICIPANT_LIMIT_EXCEEDED);
     }
 }

--- a/src/main/java/com/develop_ping/union/gathering/domain/GatheringManager.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/GatheringManager.java
@@ -5,6 +5,8 @@ import com.develop_ping.union.gathering.domain.dto.response.GatheringInfo;
 import com.develop_ping.union.gathering.domain.entity.Gathering;
 import org.springframework.data.domain.Slice;
 
+import java.util.Optional;
+
 public interface GatheringManager {
 
     GatheringInfo save(Gathering gathering);
@@ -12,4 +14,12 @@ public interface GatheringManager {
     Slice<Gathering> getGatheringList(GatheringSortStrategy strategy, GatheringListCommand command);
     Gathering findById(Long gatheringId);
     void deleteGathering(Long gatheringId);
+    Optional<Gathering> findWithPessimisticLockById(Long gatheringId);
+
+    // 유저 탈퇴시
+    //  이 유저가 가입된 모임 목록을 조회
+    //    유저의 권한이 회원 (파티 나가기)
+    //    유저의 권한이 오너 (모임, 파티 삭제) -> 모임 완전 삭제
+    // 오너 -> 모임은 보이되 유저 정보가 없는 상태로 보여줘야함
+    //
 }

--- a/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
@@ -16,6 +16,7 @@ import java.time.ZonedDateTime;
 @Table(name = "gatherings")
 public class Gathering extends AuditingFields {
 
+    // TODO: 연관 관계 고민
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -76,19 +77,16 @@ public class Gathering extends AuditingFields {
         }
     }
 
-    // TODO: 모임 참가 시 인원 제한 검증 (동시성 처리, 일단 비관락 -> 추후 낙관락으로 개선)
-    public void validateParticipantCapacity(int currentParticipants) {
-        if (currentParticipants > maxMember) {
-            throw new IllegalArgumentException("모임 인원이 초과되었습니다.");
-        }
-    }
-
     public void updateGathering(Gathering entity) {
         this.title = entity.getTitle();
         this.content = entity.getContent();
         this.maxMember = entity.getMaxMember();
         this.gatheringDateTime = entity.getGatheringDateTime();
         this.place = entity.getPlace();
+    }
+
+    public void incrementCurrentMember() {
+        this.currentMember++;
     }
 
     @Override

--- a/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringService.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringService.java
@@ -14,4 +14,5 @@ public interface GatheringService {
     GatheringInfo updateGathering(Long gatheringId, GatheringCommand command, Long userId);
     Slice<GatheringListInfo> getGatheringList(GatheringListCommand request);
     void deleteGathering(Long gatheringId, Long userId);
+    void joinGathering(Long gatheringId, Long userId);
 }

--- a/src/main/java/com/develop_ping/union/gathering/exception/ParticipantLimitExceededException.java
+++ b/src/main/java/com/develop_ping/union/gathering/exception/ParticipantLimitExceededException.java
@@ -1,0 +1,12 @@
+package com.develop_ping.union.gathering.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ParticipantLimitExceededException extends RuntimeException {
+    private final String message;
+
+    public ParticipantLimitExceededException(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/develop_ping/union/gathering/infra/GatheringManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/gathering/infra/GatheringManagerImpl.java
@@ -12,6 +12,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Slf4j
 @Component
 @Transactional(readOnly = true)
@@ -55,5 +57,10 @@ public class GatheringManagerImpl implements GatheringManager {
     @Override
     public void deleteGathering(Long gatheringId) {
         gatheringRepository.deleteById(gatheringId);
+    }
+
+    @Override
+    public Optional<Gathering> findWithPessimisticLockById(Long gatheringId) {
+        return gatheringRepository.findWithPessimisticLockById(gatheringId);
     }
 }

--- a/src/main/java/com/develop_ping/union/gathering/infra/GatheringRepository.java
+++ b/src/main/java/com/develop_ping/union/gathering/infra/GatheringRepository.java
@@ -1,13 +1,17 @@
 package com.develop_ping.union.gathering.infra;
 
 import com.develop_ping.union.gathering.domain.entity.Gathering;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface GatheringRepository extends JpaRepository<Gathering, Long> {
@@ -67,4 +71,9 @@ public interface GatheringRepository extends JpaRepository<Gathering, Long> {
      */
     @Query("SELECT g FROM Gathering g WHERE g.gatheringDateTime > CURRENT_TIMESTAMP ORDER BY g.gatheringDateTime ASC")
     Slice<Gathering> findByGatheringDateTimeAsc(Pageable pageable);
+
+    // TODO: 비관적 락 -> 낙관적 락으로 개선 필요 (동시성 이슈가 많이 발생하지 않을 것 같음)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT g FROM Gathering g WHERE g.id = :gatheringId")
+    Optional<Gathering> findWithPessimisticLockById(@Param("gatheringId") Long gatheringId);
 }

--- a/src/main/java/com/develop_ping/union/gathering/presentation/GatheringController.java
+++ b/src/main/java/com/develop_ping/union/gathering/presentation/GatheringController.java
@@ -1,6 +1,5 @@
 package com.develop_ping.union.gathering.presentation;
 
-import com.amazonaws.Response;
 import com.develop_ping.union.gathering.domain.SortType;
 import com.develop_ping.union.gathering.domain.dto.request.GatheringListCommand;
 import com.develop_ping.union.gathering.domain.dto.response.GatheringDetailInfo;
@@ -83,9 +82,9 @@ public class GatheringController {
         log.info("모임 수정 컨트롤러 진입: {}", gatheringId);
 
         Long userId = user.getId();
-        gatheringService.updateGathering(gatheringId, request.toCommand(), userId);
+        GatheringInfo gatheringInfo = gatheringService.updateGathering(gatheringId, request.toCommand(), userId);
 
-        log.info("모임 수정 완료: {}", gatheringId);
+        log.info("모임 수정 완료: {}", gatheringInfo.getId());
         return ResponseEntity.ok().build();
     }
 
@@ -100,5 +99,18 @@ public class GatheringController {
         gatheringService.deleteGathering(gatheringId, userId);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/gathering/{gatheringId}/participants")
+    public ResponseEntity<Void> joinGathering(
+        @AuthenticationPrincipal User user,
+        @PathVariable("gatheringId") Long gatheringId
+    ) {
+        log.info("모임 참가 컨트롤러 진입: {}", gatheringId);
+
+        Long userId = user.getId();
+        gatheringService.joinGathering(gatheringId, userId);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/develop_ping/union/party/domain/PartyManager.java
+++ b/src/main/java/com/develop_ping/union/party/domain/PartyManager.java
@@ -6,7 +6,7 @@ import com.develop_ping.union.party.domain.entity.Party;
 public interface PartyManager {
 
     PartyInfo createParty(Long gatheringId, Long userId);
-    PartyInfo findByGatheringId(Long gatheringId);
-    Party findOwnerByGatheringId(Long gatheringId);
+    Party findByGatheringId(Long gatheringId);
     void deleteParty(Long gatheringId);
+    void joinGathering(Long gatheringId, Long userId);
 }

--- a/src/main/java/com/develop_ping/union/party/domain/entity/Party.java
+++ b/src/main/java/com/develop_ping/union/party/domain/entity/Party.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "parties")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Party extends AuditingFields {
+    // TODO: 연관 관계 고민
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/develop_ping/union/party/exception/AlreadyJoinedException.java
+++ b/src/main/java/com/develop_ping/union/party/exception/AlreadyJoinedException.java
@@ -1,0 +1,12 @@
+package com.develop_ping.union.party.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AlreadyJoinedException extends RuntimeException {
+    private final String message;
+
+    public AlreadyJoinedException(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/develop_ping/union/party/infra/PartyManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/party/infra/PartyManagerImpl.java
@@ -1,10 +1,14 @@
 package com.develop_ping.union.party.infra;
 
+import com.develop_ping.union.gathering.domain.GatheringManager;
+import com.develop_ping.union.gathering.domain.entity.Gathering;
 import com.develop_ping.union.gathering.exception.GatheringNotFoundException;
+import com.develop_ping.union.gathering.exception.ParticipantLimitExceededException;
 import com.develop_ping.union.party.domain.PartyManager;
 import com.develop_ping.union.party.domain.dto.PartyInfo;
 import com.develop_ping.union.party.domain.entity.Party;
 import com.develop_ping.union.party.domain.entity.PartyRole;
+import com.develop_ping.union.party.exception.AlreadyJoinedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,6 +17,7 @@ import org.springframework.stereotype.Component;
 public class PartyManagerImpl implements PartyManager {
 
     private final PartyRepository partyRepository;
+    private final GatheringManager gatheringManager;
 
     @Override
     public PartyInfo createParty(Long gatheringId, Long userId) {
@@ -26,22 +31,42 @@ public class PartyManagerImpl implements PartyManager {
     }
 
     @Override
-    public PartyInfo findByGatheringId(Long gatheringId) {
-        Party party = partyRepository.findByGatheringId(gatheringId)
-                                     .orElseThrow(() -> new GatheringNotFoundException(gatheringId));
-
-        return PartyInfo.of(party);
-    }
-
-    // 파티 참여자 정보 구하는 API
-    @Override
-    public Party findOwnerByGatheringId(Long gatheringId) {
-        return partyRepository.findByGatheringIdAndRole(gatheringId, PartyRole.OWNER)
+    public Party findByGatheringId(Long gatheringId) {
+        return partyRepository.findByGatheringId(gatheringId)
                               .orElseThrow(() -> new GatheringNotFoundException(gatheringId));
     }
 
     @Override
     public void deleteParty(Long gatheringId) {
         partyRepository.deleteByGatheringId(gatheringId);
+    }
+
+    @Override
+    public void joinGathering(Long gatheringId, Long userId) {
+        Gathering gathering = gatheringManager.findWithPessimisticLockById(gatheringId)
+                                              .orElseThrow(() -> new GatheringNotFoundException(gatheringId));
+
+        gathering.incrementCurrentMember();
+        validateJoinConditions(gatheringId, userId, gathering);
+
+        Party party = Party.builder()
+                           .gatheringId(gatheringId)
+                           .userId(userId)
+                           .role(PartyRole.PARTICIPANT)
+                           .build();
+
+        partyRepository.save(party);
+        gatheringManager.save(gathering);
+    }
+
+    // TODO: 도메인 로직으로 내리는 것이 좋을까?
+    private void validateJoinConditions(Long gatheringId, Long userId, Gathering gathering) {
+        if (partyRepository.existsByGatheringIdAndUserId(gatheringId, userId)) {
+            throw new AlreadyJoinedException("이미 해당 모임에 참여하셨습니다.");
+        }
+
+        if (gathering.getCurrentMember() > gathering.getMaxMember()) {
+            throw new ParticipantLimitExceededException("모임 인원이 가득 찼습니다.");
+        }
     }
 }

--- a/src/main/java/com/develop_ping/union/party/infra/PartyRepository.java
+++ b/src/main/java/com/develop_ping/union/party/infra/PartyRepository.java
@@ -12,4 +12,5 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
     Optional<Party> findByGatheringIdAndRole(Long gatheringId, PartyRole partyRole);
     Optional<Party> findByGatheringId(Long gatheringId);
     void deleteByGatheringId(Long gatheringId);
+    boolean existsByGatheringIdAndUserId(Long gatheringId, Long userId);
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #86 

## 📝 작업 내용
- 모입 가입 API
- 비관적 락 적용

## 🎸 기타 (선택)
- 동시성 요청이 모임 가입 정도에서 비관적 락 까지 필요하지 않을 것 같아 추후 낙관락으로 개선 필요
- 관련된 파일은 [GatheringRepository.java](https://github.com/development-ping/UNION-back/compare/feat/%2386-join-gathering?expand=1#diff-bced51e10a976dc7aa2ce2b8d949b90cd050334f96032ce9a7ec92e3b37d4963)에서 확인 가능

## 💬 리뷰 요구사항(선택)
