### PR TITLE
feat: 타겟의 사진 리스트 반환(#101)

### DIFF
--- a/src/main/java/com/develop_ping/union/photo/domain/PhotoManager.java
+++ b/src/main/java/com/develop_ping/union/photo/domain/PhotoManager.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface PhotoManager {
     List<Photo> savePhotos(Long targetId, TargetType targetType, List<String> urls);
+    List<String> findPostPhotos(Long targetId);
+    List<String> findGatheringPhotos(Long targetId);
 }

--- a/src/main/java/com/develop_ping/union/photo/domain/service/PhotoServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/photo/domain/service/PhotoServiceImpl.java
@@ -3,6 +3,9 @@ package com.develop_ping.union.photo.domain.service;
 import com.develop_ping.union.photo.domain.PhotoManager;
 import com.develop_ping.union.photo.domain.dto.PhotoCommand;
 import com.develop_ping.union.photo.domain.entity.Photo;
+import com.develop_ping.union.post.domain.PostManager;
+import com.develop_ping.union.post.domain.entity.Post;
+import com.develop_ping.union.post.exception.PostPermissionDeniedException;
 import com.develop_ping.union.s3.infra.S3Manager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +19,7 @@ import java.util.List;
 public class PhotoServiceImpl implements PhotoService {
     private final PhotoManager photoManager;
     private final S3Manager s3Manager;
+    private final PostManager postManager;
 
     @Override
     public void savePhotos(PhotoCommand command) {
@@ -43,6 +47,6 @@ public class PhotoServiceImpl implements PhotoService {
     }
 
     private void validatePostOwner(Long userId, Long postId) {
-        // TODO: userId로 postId의 owner인지 확인
+        postManager.validatePostOwner(userId, postId);
     }
 }

--- a/src/main/java/com/develop_ping/union/photo/infra/PhotoManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/photo/infra/PhotoManagerImpl.java
@@ -28,4 +28,24 @@ public class PhotoManagerImpl implements PhotoManager {
 
         return photoRepository.saveAll(photos);
     }
+
+    @Override
+    public List<String> findPostPhotos(Long targetId) {
+        TargetType targetType = TargetType.POST;
+
+        return photoRepository.findByTargetIdAndTargetType(targetId, targetType)
+                .stream()
+                .map(Photo::getUrl)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> findGatheringPhotos(Long targetId) {
+        TargetType targetType = TargetType.GATHERING;
+
+        return photoRepository.findByTargetIdAndTargetType(targetId, targetType)
+                .stream()
+                .map(Photo::getUrl)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/develop_ping/union/photo/infra/PhotoRepository.java
+++ b/src/main/java/com/develop_ping/union/photo/infra/PhotoRepository.java
@@ -1,9 +1,13 @@
 package com.develop_ping.union.photo.infra;
 
 import com.develop_ping.union.photo.domain.entity.Photo;
+import com.develop_ping.union.photo.domain.entity.TargetType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
+    List<Photo> findByTargetIdAndTargetType(Long targetId, TargetType targetType);
 }

--- a/src/main/java/com/develop_ping/union/post/domain/PostManager.java
+++ b/src/main/java/com/develop_ping/union/post/domain/PostManager.java
@@ -14,4 +14,5 @@ public interface PostManager {
     Page<Post> findByPostType(PostType postType, Pageable pageable);
     Page<Post> findByUser(User user, Pageable pageable);
     Page<Post> findPostsByUserComments(User user, Pageable pageable);
+    Post validatePostOwner(Long userId, Long postId);
 }

--- a/src/main/java/com/develop_ping/union/post/domain/dto/info/PostInfo.java
+++ b/src/main/java/com/develop_ping/union/post/domain/dto/info/PostInfo.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,6 +24,7 @@ public class PostInfo {
     private String profileImage;
     private String univName;
     private ZonedDateTime createdAt;
+    private List<String> photos;
 
     @Builder
     public PostInfo(Long id,
@@ -35,7 +37,8 @@ public class PostInfo {
                     String nickname,
                     String profileImage,
                     String univName,
-                    ZonedDateTime createdAt
+                    ZonedDateTime createdAt,
+                    List<String> photos
     ) {
         this.id = id;
         this.title = title;
@@ -48,6 +51,7 @@ public class PostInfo {
         this.profileImage = profileImage;
         this.univName = univName;
         this.createdAt = createdAt;
+        this.photos = photos;
     }
 
     public static PostInfo from(Post post) {
@@ -63,6 +67,23 @@ public class PostInfo {
                 .profileImage(post.getUser().getProfileImage())
                 .univName(post.getUser().getUnivName())
                 .createdAt(post.getCreatedAt())
+                .build();
+    }
+
+    public static PostInfo of(Post post, List<String> photos) {
+        return PostInfo.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .type(post.getType())
+                .thumbnail(post.getThumbnail())
+                .views(post.getViews())
+                .token(post.getUser().getToken())
+                .nickname(post.getUser().getNickname())
+                .profileImage(post.getUser().getProfileImage())
+                .univName(post.getUser().getUnivName())
+                .createdAt(post.getCreatedAt())
+                .photos(photos)
                 .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/post/infra/PostManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/post/infra/PostManagerImpl.java
@@ -4,6 +4,7 @@ import com.develop_ping.union.post.domain.entity.Post;
 import com.develop_ping.union.post.domain.PostManager;
 import com.develop_ping.union.post.domain.entity.PostType;
 import com.develop_ping.union.post.exception.PostNotFoundException;
+import com.develop_ping.union.post.exception.PostPermissionDeniedException;
 import com.develop_ping.union.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,20 +20,17 @@ public class PostManagerImpl implements PostManager {
     private final PostRepository postRepository;
 
     @Override
-    @Transactional
     public Post saveAndFlush(Post post) {
         return postRepository.saveAndFlush(post);
     }
 
     @Override
-    @Transactional
     public Post findById(Long id) {
         return postRepository.findById(id)
                 .orElseThrow(() -> new PostNotFoundException(id));
     }
 
     @Override
-    @Transactional
     public Post save(Post post) {
         return postRepository.save(post);
     }
@@ -56,5 +54,16 @@ public class PostManagerImpl implements PostManager {
     @Override
     public Page<Post> findPostsByUserComments(User user, Pageable pageable) {
         return postRepository.findPostsByUserComments(user, pageable);
+    }
+
+    @Override
+    public Post validatePostOwner(Long userId, Long postId) {
+        Post post = findById(postId);
+
+        if (!userId.equals(post.getUser().getId())) {
+            throw new PostPermissionDeniedException(userId, post.getId());
+        }
+
+        return post;
     }
 }

--- a/src/main/java/com/develop_ping/union/post/presentation/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/develop_ping/union/post/presentation/dto/response/PostDetailResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -19,6 +20,7 @@ public class PostDetailResponse {
     private Integer views;
     private ZonedDateTime createdAt;
     private AuthorResponse author;
+    private List<String> photos;
 
 
     @Builder
@@ -28,7 +30,8 @@ public class PostDetailResponse {
                               PostType type,
                               Integer views,
                               ZonedDateTime createdAt,
-                              AuthorResponse author) {
+                              AuthorResponse author,
+                              List<String> photos) {
         this.id = id;
         this.title = title;
         this.content = content;
@@ -36,6 +39,7 @@ public class PostDetailResponse {
         this.views = views;
         this.createdAt = createdAt;
         this.author = author;
+        this.photos = photos;
     }
 
     public static PostDetailResponse from(PostInfo postInfo) {
@@ -47,6 +51,7 @@ public class PostDetailResponse {
                 .views(postInfo.getViews())
                 .createdAt(postInfo.getCreatedAt())
                 .author(AuthorResponse.from(postInfo))
+                .photos(postInfo.getPhotos())
                 .build();
     }
 


### PR DESCRIPTION
## ⚡️ 관련 이슈

> close #101 

## 📝 작업 내용

> 해당 타겟의 사진 url을  List<String> 형식으로 반환합니다.
> 기능을 사용하고 싶다면 `photoManager.find[Post/Gathering]Photos(Long targetId)`를 호출하시면 됩니다.

> 게시글 상세에 photos 필드가 추가되었습니다.

## 🎸 기타 (선택)
> 

## 💬 리뷰 요구사항(선택)

> 
