### PR TITLE
feat: 게시글 좋아요 수 조회 임시 구현(#106)

### DIFF
--- a/src/main/java/com/develop_ping/union/reaction/presentation/ReactionController.java
+++ b/src/main/java/com/develop_ping/union/reaction/presentation/ReactionController.java
@@ -1,0 +1,27 @@
+package com.develop_ping.union.reaction.presentation;
+
+import com.develop_ping.union.reaction.presentation.dto.PostReactionResponse;
+import com.develop_ping.union.user.domain.entity.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+public class ReactionController {
+    @GetMapping("/{postId}/likes")
+    public ResponseEntity<PostReactionResponse> getPostLikes(@PathVariable("postId") Long postId,
+                                                             @AuthenticationPrincipal User user) {
+        log.info("[ CALL: ReactionController.getPostLikes() ] with postId: {}", postId);
+
+        PostReactionResponse response = PostReactionResponse.builder()
+            .postLikes(123)
+            .liked(false)
+            .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/develop_ping/union/reaction/presentation/dto/PostReactionResponse.java
+++ b/src/main/java/com/develop_ping/union/reaction/presentation/dto/PostReactionResponse.java
@@ -1,0 +1,19 @@
+package com.develop_ping.union.reaction.presentation.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostReactionResponse {
+    private int PostLikes;
+    private boolean liked;
+
+    @Builder
+    public PostReactionResponse(int postLikes, boolean liked) {
+        this.PostLikes = postLikes;
+        this.liked = liked;
+    }
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈

> close #106 

## 📝 작업 내용

> 게시글 상세 조회에서 쓰이는 게시글 좋아요 수 조회를 임시로 구현해두었습니다.

## 🎸 기타 (선택)
> 고려해야 하는 내용을 작성해 주세요.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
