### PR TITLE
feat: 댓글 수 기능 구현 및 하드코딩 제거(#111)

### DIFF
--- a/src/main/java/com/develop_ping/union/comment/domain/CommentManager.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/CommentManager.java
@@ -9,4 +9,5 @@ public interface CommentManager {
     Comment findById(Long id);
     void delete(Comment comment);
     List<Comment> findByPostIdAndParentIsNull(Long postId);
+    long countByPostId(Long postId);
 }

--- a/src/main/java/com/develop_ping/union/comment/domain/dto/CommentListInfo.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/dto/CommentListInfo.java
@@ -13,19 +13,22 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentListInfo {
     private List<CommentInfo> comments;
+    private long commentCount;
 
     @Builder
-    private CommentListInfo(List<CommentInfo> comments) {
+    private CommentListInfo(List<CommentInfo> comments, long commentCount) {
         this.comments = comments;
+        this.commentCount = commentCount;
     }
 
-    public static CommentListInfo of(List<Comment> rootComments) {
+    public static CommentListInfo of(List<Comment> rootComments, long commentCount) {
         List<CommentInfo> commentInfos = rootComments.stream()
                 .map(CommentInfo::of)
                 .collect(Collectors.toList());
 
         return CommentListInfo.builder()
                 .comments(commentInfos)
+                .commentCount(commentCount)
                 .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/domain/service/CommentServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/service/CommentServiceImpl.java
@@ -95,8 +95,10 @@ public class CommentServiceImpl implements CommentService {
 
         // TODO: rootComments 랑 children 을 각각 for문이나 stream 돌려서 User deleted 확인 + blockUsers 확인해서 제외(null처리)해주기
 
+        long count = commentManager.countByPostId(post.getId());
+
         log.info("[ Comments Retrieval Completed! ]");
-        return CommentListInfo.of(rootComments);
+        return CommentListInfo.of(rootComments, count);
     }
 
     private void validateCommentOwner(User user, Comment comment) {

--- a/src/main/java/com/develop_ping/union/comment/infra/CommentManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/comment/infra/CommentManagerImpl.java
@@ -36,4 +36,9 @@ public class CommentManagerImpl implements CommentManager {
     public List<Comment> findByPostIdAndParentIsNull(Long postId) {
         return commentRepository.findByPostIdAndParentIsNull(postId);
     }
+
+    @Override
+    public long countByPostId(Long postId) {
+        return commentRepository.countByPostId(postId);
+    }
 }

--- a/src/main/java/com/develop_ping/union/comment/infra/CommentRepository.java
+++ b/src/main/java/com/develop_ping/union/comment/infra/CommentRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostIdAndParentIsNull(Long postId);
+    long countByPostId(Long postId);
 }

--- a/src/main/java/com/develop_ping/union/comment/presentation/CommentController.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/CommentController.java
@@ -52,6 +52,7 @@ public class CommentController {
         return ResponseEntity.noContent().build();
     }
 
+    // 개발 확인용 API (단일 댓글 내용 조회)
     @GetMapping("/comment/{commentId}")
     public ResponseEntity<CommentDetailResponse> getComment(@PathVariable("commentId") Long commentId) {
         log.info("[ CALL: CommentController.getComment() ] with commentId: {}", commentId);

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentListResponse.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentListResponse.java
@@ -13,10 +13,12 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentListResponse {
     private List<CommentDetailResponse> comments;
+    private long commentCount;
 
     @Builder
-    private CommentListResponse(List<CommentDetailResponse> comments) {
+    private CommentListResponse(List<CommentDetailResponse> comments, long commentCount) {
         this.comments = comments;
+        this.commentCount = commentCount;
     }
 
     public static CommentListResponse from(CommentListInfo listInfo) {
@@ -26,6 +28,7 @@ public class CommentListResponse {
 
         return CommentListResponse.builder()
                 .comments(responseList)
+                .commentCount(listInfo.getCommentCount())
                 .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/post/domain/dto/info/PostInfo.java
+++ b/src/main/java/com/develop_ping/union/post/domain/dto/info/PostInfo.java
@@ -57,16 +57,6 @@ public class PostInfo {
     public static PostInfo from(Post post) {
         return PostInfo.builder()
                 .id(post.getId())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .type(post.getType())
-                .thumbnail(post.getThumbnail())
-                .views(post.getViews())
-                .token(post.getUser().getToken())
-                .nickname(post.getUser().getNickname())
-                .profileImage(post.getUser().getProfileImage())
-                .univName(post.getUser().getUnivName())
-                .createdAt(post.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/com/develop_ping/union/post/domain/dto/info/PostListInfo.java
+++ b/src/main/java/com/develop_ping/union/post/domain/dto/info/PostListInfo.java
@@ -22,8 +22,8 @@ public class PostListInfo {
     private String univName;
     private ZonedDateTime createdAt;
     private Integer views;
-    private Integer postLikes;
-    private Integer CommentCount;
+    private long postLikes;
+    private long commentCount;
 
     @Builder
     private PostListInfo(Long id,
@@ -36,8 +36,8 @@ public class PostListInfo {
                         String univName,
                         ZonedDateTime createdAt,
                         Integer views,
-                        Integer postLikes,
-                        Integer CommentCount) {
+                        long postLikes,
+                        long commentCount) {
         this.id = id;
         this.title = title;
         this.contentPreview = contentPreview;
@@ -49,16 +49,15 @@ public class PostListInfo {
         this.createdAt = createdAt;
         this.views = views;
         this.postLikes = postLikes;
-        this.CommentCount = CommentCount;
+        this.commentCount = commentCount;
     }
 
-    public static PostListInfo from(Post post) {
+    public static PostListInfo of(Post post, long postLikes, long commentCount) {
         // content가 20자를 초과할 경우 '...' 추가
         String contentPreview = post.getContent().length() > 20
                 ? post.getContent().substring(0, 20) + "..."
                 : post.getContent();
 
-        // TODO: postLikes, CommentCount 추가
         return PostListInfo.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -69,8 +68,8 @@ public class PostListInfo {
                 .univName(post.getUser().getUnivName())
                 .createdAt(post.getCreatedAt())
                 .views(post.getViews())
-                .postLikes(0)
-                .CommentCount(0)
+                .postLikes(postLikes)
+                .commentCount(commentCount)
                 .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/post/presentation/PostListController.java
+++ b/src/main/java/com/develop_ping/union/post/presentation/PostListController.java
@@ -38,7 +38,7 @@ public class PostListController {
         return postListInfoPage.map(PostListResponse::from);
     }
 
-    @GetMapping("/user/my/post")
+    @GetMapping("/user/my/posts")
     public Page<PostListResponse> getMyPostList(@RequestParam(defaultValue = "0") int page,
                                                 @RequestParam(defaultValue = "3") int size,
                                                 @AuthenticationPrincipal User user) {
@@ -68,7 +68,7 @@ public class PostListController {
         return postListInfoPage.map(PostListResponse::from);
     }
 
-    @GetMapping("/user/{userToken}/post")
+    @GetMapping("/user/{userToken}/posts")
     public Page<PostListResponse> getUserPostList(@PathVariable("userToken") String userToken,
                                                   @RequestParam(defaultValue = "0") int page,
                                                   @RequestParam(defaultValue = "3") int size) {

--- a/src/main/java/com/develop_ping/union/post/presentation/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/develop_ping/union/post/presentation/dto/response/PostDetailResponse.java
@@ -22,7 +22,6 @@ public class PostDetailResponse {
     private AuthorResponse author;
     private List<String> photos;
 
-
     @Builder
     public PostDetailResponse(Long id,
                               String title,

--- a/src/main/java/com/develop_ping/union/post/presentation/dto/response/PostListResponse.java
+++ b/src/main/java/com/develop_ping/union/post/presentation/dto/response/PostListResponse.java
@@ -18,8 +18,8 @@ public class PostListResponse {
     private ZonedDateTime createdAt;
     private AuthorResponse author;
     private Integer views;
-    private Integer postLikes;
-    private Integer commentCount;
+    private long postLikes;
+    private long commentCount;
 
     @Builder
     public PostListResponse(Long id,
@@ -29,8 +29,8 @@ public class PostListResponse {
                             ZonedDateTime createdAt,
                             AuthorResponse author,
                             Integer views,
-                            Integer postLikes,
-                            Integer commentCount) {
+                            long postLikes,
+                            long commentCount) {
         this.id = id;
         this.title = title;
         this.contentPreview = contentPreview;


### PR DESCRIPTION
## ⚡️ 관련 이슈

> close #111

## 📝 작업 내용

> comment list 조회 시 댓글 수 필드 추가
> post list 조회 시 하드코딩된 댓글 수를 실제 DB 조회로 변경

> `PostInfo.from()` 데이터 단순화

> `PostListController` 테스트 때 임시로 변경한 엔드포인트 정상화

## 🎸 기타 (선택)
> post list의 경우 추후 캐싱이나 배치 작업 필요

## 💬 리뷰 요구사항(선택)

> 
