### PR TITLE
fix: post list 응답에 post type 필드 추가(#114)

### DIFF
--- a/src/main/java/com/develop_ping/union/post/domain/dto/info/PostListInfo.java
+++ b/src/main/java/com/develop_ping/union/post/domain/dto/info/PostListInfo.java
@@ -13,9 +13,9 @@ import java.time.ZonedDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostListInfo {
     private Long id;
+    private PostType type;
     private String title;
     private String contentPreview;
-    private PostType type;
     private String thumbnail;
     private String nickname;
     private String profileImage;
@@ -27,21 +27,21 @@ public class PostListInfo {
 
     @Builder
     private PostListInfo(Long id,
-                        String title,
-                        String contentPreview,
-                        PostType type,
-                        String thumbnail,
-                        String nickname,
-                        String profileImage,
-                        String univName,
-                        ZonedDateTime createdAt,
-                        Integer views,
-                        long postLikes,
-                        long commentCount) {
+                         PostType type,
+                         String title,
+                         String contentPreview,
+                         String thumbnail,
+                         String nickname,
+                         String profileImage,
+                         String univName,
+                         ZonedDateTime createdAt,
+                         Integer views,
+                         long postLikes,
+                         long commentCount) {
         this.id = id;
+        this.type = type;
         this.title = title;
         this.contentPreview = contentPreview;
-        this.type = type;
         this.thumbnail = thumbnail;
         this.nickname = nickname;
         this.profileImage = profileImage;
@@ -60,6 +60,7 @@ public class PostListInfo {
 
         return PostListInfo.builder()
                 .id(post.getId())
+                .type(post.getType())
                 .title(post.getTitle())
                 .contentPreview(contentPreview)
                 .thumbnail(post.getThumbnail())

--- a/src/main/java/com/develop_ping/union/post/presentation/dto/response/PostListResponse.java
+++ b/src/main/java/com/develop_ping/union/post/presentation/dto/response/PostListResponse.java
@@ -1,6 +1,7 @@
 package com.develop_ping.union.post.presentation.dto.response;
 
 import com.develop_ping.union.post.domain.dto.info.PostListInfo;
+import com.develop_ping.union.post.domain.entity.PostType;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import java.time.ZonedDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostListResponse {
     private Long id;
+    private PostType type;
     private String title;
     private String contentPreview;
     private String thumbnail;
@@ -23,6 +25,7 @@ public class PostListResponse {
 
     @Builder
     public PostListResponse(Long id,
+                            PostType type,
                             String title,
                             String contentPreview,
                             String thumbnail,
@@ -32,6 +35,7 @@ public class PostListResponse {
                             long postLikes,
                             long commentCount) {
         this.id = id;
+        this.type = type;
         this.title = title;
         this.contentPreview = contentPreview;
         this.thumbnail = thumbnail;
@@ -45,6 +49,7 @@ public class PostListResponse {
     public static PostListResponse from(PostListInfo info) {
         return PostListResponse.builder()
                 .id(info.getId())
+                .type(info.getType())
                 .title(info.getTitle())
                 .contentPreview(info.getContentPreview())
                 .thumbnail(info.getThumbnail())


### PR DESCRIPTION
## ⚡️ 관련 이슈

> close #114 

## 📝 작업 내용

> post list 응답에 post type 필드를 추가했습니다.

