### PR TITLE
feat: 모임 상세 보기 정보 추가

### DIFF
--- a/src/main/java/com/develop_ping/union/gathering/domain/GatheringManager.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/GatheringManager.java
@@ -10,7 +10,6 @@ import org.springframework.data.domain.Slice;
 public interface GatheringManager {
 
     GatheringInfo save(Gathering gathering);
-    GatheringInfo getGatheringDetail(Long gatheringId);
     Slice<Gathering> getGatheringList(GatheringSortStrategy strategy, GatheringListCommand command);
     Gathering findById(Long gatheringId);
     void deleteGathering(Gathering gathering);

--- a/src/main/java/com/develop_ping/union/gathering/domain/dto/response/GatheringDetailInfo.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/dto/response/GatheringDetailInfo.java
@@ -1,57 +1,34 @@
 package com.develop_ping.union.gathering.domain.dto.response;
 
+import com.develop_ping.union.user.domain.entity.User;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.ZonedDateTime;
 
 @Getter
 public class GatheringDetailInfo {
 
-    private final Long id;
-    private final String title;
-    private final String content;
-    private final Integer maxMember;
-    private final Integer currentMember;
-    private final String address;
-    private final Double latitude;
-    private final Double longitude;
-    private final String eupMyeonDong;
-    private final ZonedDateTime gatheringDateTime;
-    private final Long views;
-    private final ZonedDateTime createdAt;
-    private final String userNickname;
+    private final GatheringInfo gatheringInfo;
+    private final User user;
     private final Long likes;
     private final boolean isOwner;
 
     @Builder
-    public GatheringDetailInfo(
+    private GatheringDetailInfo(
         GatheringInfo gatheringInfo,
-        String userNickname,
+        User user,
         Long likes,
         boolean isOwner
     ) {
-        this.id = gatheringInfo.getId();
-        this.title = gatheringInfo.getTitle();
-        this.content = gatheringInfo.getContent();
-        this.maxMember = gatheringInfo.getMaxMember();
-        this.currentMember = gatheringInfo.getCurrentMember();
-        this.address = gatheringInfo.getAddress();
-        this.latitude = gatheringInfo.getLatitude();
-        this.longitude = gatheringInfo.getLongitude();
-        this.gatheringDateTime = gatheringInfo.getGatheringDateTime();
-        this.views = gatheringInfo.getViews();
-        this.createdAt = gatheringInfo.getCreatedAt();
-        this.eupMyeonDong = gatheringInfo.getEupMyeonDong();
-        this.userNickname = userNickname;
+        this.gatheringInfo = gatheringInfo;
+        this.user = user;
         this.likes = likes;
         this.isOwner = isOwner;
     }
 
-    public static GatheringDetailInfo of(GatheringInfo gatheringInfo, String userNickname, Long likes, boolean isOwner) {
+    public static GatheringDetailInfo of(GatheringInfo gatheringInfo, User user, Long likes, boolean isOwner) {
         return GatheringDetailInfo.builder()
                                   .gatheringInfo(gatheringInfo)
-                                  .userNickname(userNickname)
+                                  .user(user)
                                   .likes(likes)
                                   .isOwner(isOwner)
                                   .build();

--- a/src/main/java/com/develop_ping/union/gathering/domain/dto/response/GatheringDetailInfo.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/dto/response/GatheringDetailInfo.java
@@ -15,6 +15,7 @@ public class GatheringDetailInfo {
     private final boolean isOwner;
     private final boolean isLiked;
     private final List<String> photos;
+    private final boolean isJoined;
 
     @Builder
     private GatheringDetailInfo(
@@ -23,7 +24,8 @@ public class GatheringDetailInfo {
         Long likes,
         boolean isOwner,
         boolean isLiked,
-        List<String> photos
+        List<String> photos,
+        boolean isJoined
     ) {
         this.gatheringInfo = gatheringInfo;
         this.user = user;
@@ -31,15 +33,21 @@ public class GatheringDetailInfo {
         this.isOwner = isOwner;
         this.isLiked = isLiked;
         this.photos = photos;
+        this.isJoined = isJoined;
     }
 
-    public static GatheringDetailInfo of(GatheringInfo gatheringInfo, User user, Long likes, boolean isOwner) {
+    public static GatheringDetailInfo of(
+        GatheringInfo gatheringInfo, User user, Long likes,
+        boolean isOwner, List<String> photos, boolean isJoined
+    ) {
         return GatheringDetailInfo.builder()
                                   .gatheringInfo(gatheringInfo)
                                   .user(user)
                                   .likes(likes)
                                   .isLiked(false)
                                   .isOwner(isOwner)
+                                  .photos(photos)
+                                  .isJoined(isJoined)
                                   .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/gathering/domain/dto/response/GatheringDetailInfo.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/dto/response/GatheringDetailInfo.java
@@ -4,6 +4,8 @@ import com.develop_ping.union.user.domain.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class GatheringDetailInfo {
 
@@ -11,18 +13,24 @@ public class GatheringDetailInfo {
     private final User user;
     private final Long likes;
     private final boolean isOwner;
+    private final boolean isLiked;
+    private final List<String> photos;
 
     @Builder
     private GatheringDetailInfo(
         GatheringInfo gatheringInfo,
         User user,
         Long likes,
-        boolean isOwner
+        boolean isOwner,
+        boolean isLiked,
+        List<String> photos
     ) {
         this.gatheringInfo = gatheringInfo;
         this.user = user;
         this.likes = likes;
         this.isOwner = isOwner;
+        this.isLiked = isLiked;
+        this.photos = photos;
     }
 
     public static GatheringDetailInfo of(GatheringInfo gatheringInfo, User user, Long likes, boolean isOwner) {
@@ -30,6 +38,7 @@ public class GatheringDetailInfo {
                                   .gatheringInfo(gatheringInfo)
                                   .user(user)
                                   .likes(likes)
+                                  .isLiked(false)
                                   .isOwner(isOwner)
                                   .build();
     }

--- a/src/main/java/com/develop_ping/union/gathering/domain/dto/response/GatheringInfo.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/dto/response/GatheringInfo.java
@@ -23,6 +23,7 @@ public class GatheringInfo {
     private final ZonedDateTime gatheringDateTime;
     private final Long views;
     private final ZonedDateTime createdAt;
+    private final boolean recruited;
 
     @Builder
     private GatheringInfo(
@@ -37,7 +38,8 @@ public class GatheringInfo {
         String eupMyeonDong,
         ZonedDateTime gatheringDateTime,
         Long views,
-        ZonedDateTime createdAt
+        ZonedDateTime createdAt,
+        boolean recruited
     ) {
         this.id = id;
         this.title = title;
@@ -51,6 +53,7 @@ public class GatheringInfo {
         this.gatheringDateTime = gatheringDateTime;
         this.views = views;
         this.createdAt = createdAt;
+        this.recruited = recruited;
     }
 
     public static GatheringInfo of(Gathering gathering) {
@@ -67,6 +70,7 @@ public class GatheringInfo {
                             .gatheringDateTime(gathering.getGatheringDateTime())
                             .views(gathering.getViews())
                             .createdAt(gathering.getCreatedAt())
+                            .recruited(gathering.isRecruited())
                             .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
@@ -44,6 +44,7 @@ public class Gathering extends AuditingFields {
         this.gatheringDateTime = gatheringDateTime;
         this.place = place;
         this.views = 0L;
+        this.recruited = false;
     }
 
     @Id
@@ -68,8 +69,11 @@ public class Gathering extends AuditingFields {
     @Column(name = "gathering_date_time", nullable = false)
     private ZonedDateTime gatheringDateTime;
 
-    @Column(name = "views")
+    @Column(name = "views", nullable = false)
     private Long views;
+
+    @Column(name = "recruited", nullable = false)
+    private boolean recruited;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "gathering", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Party> parties = new ArrayList<>();

--- a/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
@@ -161,4 +161,8 @@ public class Gathering extends AuditingFields {
     public void close() {
         this.recruited = true;
     }
+
+    public void open() {
+        this.recruited = false;
+    }
 }

--- a/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
@@ -121,6 +121,10 @@ public class Gathering extends AuditingFields {
         }
     }
 
+    public void incrementViews() {
+        this.views++;
+    }
+
     private void validateGatheringDateTime(ZonedDateTime gatheringDateTime) {
         if (gatheringDateTime.isBefore(ZonedDateTime.now().plusMinutes(29))) {
             throw new GatheringValidationException("모임 일시는 현재 시간에서 30분 이후로 설정해주세요.");

--- a/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/entity/Gathering.java
@@ -153,4 +153,12 @@ public class Gathering extends AuditingFields {
                ", gatheringDateTime=" + gatheringDateTime +
                '}';
     }
+
+    public boolean isFull() {
+        return this.currentMember >= this.maxMember;
+    }
+
+    public void close() {
+        this.recruited = true;
+    }
 }

--- a/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImpl.java
@@ -145,6 +145,11 @@ public class GatheringServiceImpl implements GatheringService {
 
         gathering.getParties().add(party);
         gathering.incrementCurrentMember();
+
+        if (gathering.isFull()) {
+            gathering.close();
+        }
+
         gatheringManager.save(gathering);
     }
 

--- a/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImpl.java
@@ -69,6 +69,9 @@ public class GatheringServiceImpl implements GatheringService {
         User owner = ownerParty.getUser();
         boolean isOwner = gathering.isOwner(user);
 
+        // 모임 참가 여부
+        boolean isJoined = partyManager.existsByGatheringAndUser(gathering, user);
+
         // 좋아요 수
         Long likes = reactionManager.selectLikeCount(gathering.getId());
 
@@ -88,6 +91,7 @@ public class GatheringServiceImpl implements GatheringService {
                                   .isOwner(isOwner)
                                   .isLiked(isLiked)
                                   .photos(photos)
+                                  .isJoined(isJoined)
                                   .build();
     }
 

--- a/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImpl.java
@@ -55,7 +55,11 @@ public class GatheringServiceImpl implements GatheringService {
 
         Gathering gathering = gatheringManager.findById(gatheringId);
 
-        Party ownerParty = partyManager.findOwnerByGathering(gatheringId);
+        // TODO: 조회수 증가 부분 성능 이슈 신경쓰기
+        gathering.incrementViews();
+        gatheringManager.save(gathering);
+
+        Party ownerParty = partyManager.findOwnerByGatheringIdAndRole(gatheringId, PartyRole.OWNER);
         User owner = ownerParty.getUser();
         boolean isOwner = gathering.isOwner(user);
 
@@ -122,7 +126,7 @@ public class GatheringServiceImpl implements GatheringService {
     @Override
     @Transactional
     public void exitGathering(Long gatheringId, User user) {
-        log.info("\n모임 나가기 exitGathering ServiceImpl 클래스 : gatheringID {}, user {}", gatheringId, user.getId());
+        log.info("\n모임 나가기 (exitGathering) ServiceImpl 클래스 : gatheringID {}, user {}", gatheringId, user.getId());
 
         Gathering gathering = gatheringManager.findById(gatheringId);
 

--- a/src/main/java/com/develop_ping/union/gathering/infra/GatheringManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/gathering/infra/GatheringManagerImpl.java
@@ -6,6 +6,8 @@ import com.develop_ping.union.gathering.domain.dto.request.GatheringListCommand;
 import com.develop_ping.union.gathering.domain.dto.response.GatheringInfo;
 import com.develop_ping.union.gathering.domain.entity.Gathering;
 import com.develop_ping.union.gathering.exception.GatheringNotFoundException;
+import com.develop_ping.union.party.domain.PartyManager;
+import com.develop_ping.union.party.domain.entity.Party;
 import com.develop_ping.union.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,36 +23,28 @@ import org.springframework.transaction.annotation.Transactional;
 public class GatheringManagerImpl implements GatheringManager {
 
     private final GatheringRepository gatheringRepository;
+    private final PartyManager partyManager;
 
     @Override
     public GatheringInfo save(Gathering gathering) {
-        log.info("모임 생성 ManagerImpl 클래스 : {}", gathering);
+        log.info("\n모임 ManagerImpl 클래스 save 호출 (update, create) : {}", gathering);
 
         Gathering savedGathering = gatheringRepository.save(gathering);
         return GatheringInfo.of(savedGathering);
     }
 
     @Override
-    public GatheringInfo getGatheringDetail(Long gatheringId) {
-        log.info("모임 상세 조회 ManagerImpl 클래스 : {}", gatheringId);
-
-        gatheringRepository.incrementViewCount(gatheringId);
-        return GatheringInfo.of(gatheringRepository.findById(gatheringId)
-                                                   .orElseThrow(() -> new GatheringNotFoundException(gatheringId)));
-    }
-
-    @Override
     public Slice<Gathering> getGatheringList(
         GatheringSortStrategy strategy, GatheringListCommand command
     ) {
-        log.info("모임 리스트 조회 ManagerImpl 클래스 : {}", command);
+        log.info("\n모임 리스트 조회 ManagerImpl 클래스 : {}", command);
 
         return strategy.applySort(gatheringRepository, command, command.getPageable());
     }
 
     @Override
     public Gathering findById(Long gatheringId) {
-        log.info("모임 단순 조회 (findById) ManagerImpl 클래스 : {}", gatheringId);
+        log.info("\n모임 단순 조회 (findById) ManagerImpl 클래스 : {}", gatheringId);
 
         return gatheringRepository.findById(gatheringId)
                                   .orElseThrow(() -> new GatheringNotFoundException(gatheringId));
@@ -58,14 +52,14 @@ public class GatheringManagerImpl implements GatheringManager {
 
     @Override
     public void deleteGathering(Gathering gathering) {
-        log.info("모임 삭제 ManagerImpl 클래스 : {}", gathering);
+        log.info("\n모임 삭제 ManagerImpl 클래스 : {}", gathering);
 
         gatheringRepository.delete(gathering);
     }
 
     @Override
     public Gathering findWithPessimisticLockById(Long gatheringId) {
-        log.info("모임 조회 비관적 락 ManagerImpl 클래스 : {}", gatheringId);
+        log.info("\n모임 조회 비관적 락 ManagerImpl 클래스 : {}", gatheringId);
 
         return gatheringRepository.findWithPessimisticLockById(gatheringId)
                                   .orElseThrow(() -> new GatheringNotFoundException(gatheringId));
@@ -73,7 +67,7 @@ public class GatheringManagerImpl implements GatheringManager {
 
     @Override
     public Slice<Gathering> getMyGatheringList(User user, Pageable pageable) {
-        log.info("내가 작성한 모임 리스트 조회 ManagerImpl 클래스 : {}", user.getId());
+        log.info("\n내가 작성한 모임 리스트 조회 ManagerImpl 클래스 : {}", user.getId());
 
         return gatheringRepository.findByUserAsOwner(user, pageable);
     }

--- a/src/main/java/com/develop_ping/union/gathering/infra/GatheringManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/gathering/infra/GatheringManagerImpl.java
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class GatheringManagerImpl implements GatheringManager {
 
     private final GatheringRepository gatheringRepository;
-    private final PartyManager partyManager;
 
     @Override
     public GatheringInfo save(Gathering gathering) {

--- a/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringDetailResponse.java
+++ b/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringDetailResponse.java
@@ -1,8 +1,13 @@
 package com.develop_ping.union.gathering.presentation.dto.response;
 
 import com.develop_ping.union.gathering.domain.dto.response.GatheringDetailInfo;
+import com.develop_ping.union.gathering.domain.dto.response.GatheringInfo;
+import com.develop_ping.union.post.domain.dto.info.PostInfo;
+import com.develop_ping.union.post.presentation.dto.response.PostDetailResponse;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
 
@@ -24,6 +29,7 @@ public class GatheringDetailResponse {
     private final Long likes;
     private final Long views;
     private final boolean isOwner;
+    private final AuthorResponse author;
 
     @Builder
     private GatheringDetailResponse(
@@ -41,7 +47,8 @@ public class GatheringDetailResponse {
         ZonedDateTime createdAt,
         String userNickname,
         Long likes,
-        boolean isOwner
+        boolean isOwner,
+        AuthorResponse author
     ) {
         this.id = id;
         this.title = title;
@@ -58,25 +65,56 @@ public class GatheringDetailResponse {
         this.userNickname = userNickname;
         this.likes = likes;
         this.isOwner = isOwner;
+        this.author = author;
     }
 
     public static GatheringDetailResponse from(GatheringDetailInfo gatheringInfo) {
         return GatheringDetailResponse.builder()
-                                .id(gatheringInfo.getId())
-                                .title(gatheringInfo.getTitle())
-                                .content(gatheringInfo.getContent())
-                                .maxMember(gatheringInfo.getMaxMember())
-                                .currentMember(gatheringInfo.getCurrentMember())
-                                .address(gatheringInfo.getAddress())
-                                .latitude(gatheringInfo.getLatitude())
-                                .longitude(gatheringInfo.getLongitude())
-                                .eupMyeonDong(gatheringInfo.getEupMyeonDong())
-                                .gatheringDateTime(gatheringInfo.getGatheringDateTime())
-                                .views(gatheringInfo.getViews())
-                                .createdAt(gatheringInfo.getCreatedAt())
-                                .userNickname(gatheringInfo.getUserNickname())
-                                .likes(gatheringInfo.getLikes())
-                                .isOwner(gatheringInfo.isOwner())
-                                .build();
+                                      .id(gatheringInfo.getGatheringInfo().getId())
+                                      .title(gatheringInfo.getGatheringInfo().getTitle())
+                                      .content(gatheringInfo.getGatheringInfo().getContent())
+                                      .maxMember(gatheringInfo.getGatheringInfo().getMaxMember())
+                                      .currentMember(gatheringInfo.getGatheringInfo().getCurrentMember())
+                                      .address(gatheringInfo.getGatheringInfo().getAddress())
+                                      .latitude(gatheringInfo.getGatheringInfo().getLatitude())
+                                      .longitude(gatheringInfo.getGatheringInfo().getLongitude())
+                                      .eupMyeonDong(gatheringInfo.getGatheringInfo().getEupMyeonDong())
+                                      .gatheringDateTime(gatheringInfo.getGatheringInfo().getGatheringDateTime())
+                                      .views(gatheringInfo.getGatheringInfo().getViews())
+                                      .createdAt(gatheringInfo.getGatheringInfo().getCreatedAt())
+                                      .userNickname(gatheringInfo.getUser().getNickname())
+                                      .likes(gatheringInfo.getLikes())
+                                      .isOwner(gatheringInfo.isOwner())
+                                      .author(AuthorResponse.from(gatheringInfo))
+                                      .build();
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AuthorResponse {
+        private String token;
+        private String nickname;
+        private String profileImage;
+        private String univName;
+
+        @Builder
+        private AuthorResponse(String token,
+                               String nickname,
+                               String profileImage,
+                               String univName) {
+            this.token = token;
+            this.nickname = nickname;
+            this.profileImage = profileImage;
+            this.univName = univName;
+        }
+
+        public static GatheringDetailResponse.AuthorResponse from(GatheringDetailInfo info) {
+            return AuthorResponse.builder()
+                                 .token(info.getUser().getToken())
+                                 .nickname(info.getUser().getUnivName())
+                                 .profileImage(info.getUser().getProfileImage())
+                                 .univName(info.getUser().getUnivName())
+                                 .build();
+        }
     }
 }

--- a/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringDetailResponse.java
+++ b/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringDetailResponse.java
@@ -29,7 +29,9 @@ public class GatheringDetailResponse {
     private final boolean isOwner;
     private final boolean isLiked;
     private final AuthorResponse author;
+    private final boolean recruited;
     private final List<String> photos;
+    private final boolean isJoined;
 
     @Builder
     private GatheringDetailResponse(
@@ -50,7 +52,9 @@ public class GatheringDetailResponse {
         boolean isOwner,
         boolean isLiked,
         AuthorResponse author,
-        List<String> photos
+        List<String> photos,
+        boolean recruited,
+        boolean isJoined
     ) {
         this.id = id;
         this.title = title;
@@ -70,27 +74,32 @@ public class GatheringDetailResponse {
         this.isLiked = isLiked;
         this.author = author;
         this.photos = photos;
+        this.recruited = recruited;
+        this.isJoined = isJoined;
     }
 
-    public static GatheringDetailResponse from(GatheringDetailInfo gatheringInfo) {
+    public static GatheringDetailResponse from(GatheringDetailInfo gatheringDetailInfo) {
         return GatheringDetailResponse.builder()
-                                      .id(gatheringInfo.getGatheringInfo().getId())
-                                      .title(gatheringInfo.getGatheringInfo().getTitle())
-                                      .content(gatheringInfo.getGatheringInfo().getContent())
-                                      .maxMember(gatheringInfo.getGatheringInfo().getMaxMember())
-                                      .currentMember(gatheringInfo.getGatheringInfo().getCurrentMember())
-                                      .address(gatheringInfo.getGatheringInfo().getAddress())
-                                      .latitude(gatheringInfo.getGatheringInfo().getLatitude())
-                                      .longitude(gatheringInfo.getGatheringInfo().getLongitude())
-                                      .eupMyeonDong(gatheringInfo.getGatheringInfo().getEupMyeonDong())
-                                      .gatheringDateTime(gatheringInfo.getGatheringInfo().getGatheringDateTime())
-                                      .views(gatheringInfo.getGatheringInfo().getViews())
-                                      .createdAt(gatheringInfo.getGatheringInfo().getCreatedAt())
-                                      .userNickname(gatheringInfo.getUser().getNickname())
-                                      .likes(gatheringInfo.getLikes())
-                                      .isOwner(gatheringInfo.isOwner())
-                                      .isLiked(gatheringInfo.isLiked())
-                                      .author(AuthorResponse.from(gatheringInfo))
+                                      .id(gatheringDetailInfo.getGatheringInfo().getId())
+                                      .title(gatheringDetailInfo.getGatheringInfo().getTitle())
+                                      .content(gatheringDetailInfo.getGatheringInfo().getContent())
+                                      .maxMember(gatheringDetailInfo.getGatheringInfo().getMaxMember())
+                                      .currentMember(gatheringDetailInfo.getGatheringInfo().getCurrentMember())
+                                      .address(gatheringDetailInfo.getGatheringInfo().getAddress())
+                                      .latitude(gatheringDetailInfo.getGatheringInfo().getLatitude())
+                                      .longitude(gatheringDetailInfo.getGatheringInfo().getLongitude())
+                                      .eupMyeonDong(gatheringDetailInfo.getGatheringInfo().getEupMyeonDong())
+                                      .gatheringDateTime(gatheringDetailInfo.getGatheringInfo().getGatheringDateTime())
+                                      .views(gatheringDetailInfo.getGatheringInfo().getViews())
+                                      .createdAt(gatheringDetailInfo.getGatheringInfo().getCreatedAt())
+                                      .userNickname(gatheringDetailInfo.getUser().getNickname())
+                                      .likes(gatheringDetailInfo.getLikes())
+                                      .isOwner(gatheringDetailInfo.isOwner())
+                                      .isLiked(gatheringDetailInfo.isLiked())
+                                      .author(AuthorResponse.from(gatheringDetailInfo))
+                                      .photos(gatheringDetailInfo.getPhotos())
+                                      .recruited(gatheringDetailInfo.getGatheringInfo().isRecruited())
+                                      .isJoined(gatheringDetailInfo.isJoined())
                                       .build();
     }
 

--- a/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringDetailResponse.java
+++ b/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringDetailResponse.java
@@ -1,9 +1,6 @@
 package com.develop_ping.union.gathering.presentation.dto.response;
 
 import com.develop_ping.union.gathering.domain.dto.response.GatheringDetailInfo;
-import com.develop_ping.union.gathering.domain.dto.response.GatheringInfo;
-import com.develop_ping.union.post.domain.dto.info.PostInfo;
-import com.develop_ping.union.post.presentation.dto.response.PostDetailResponse;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringDetailResponse.java
+++ b/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringDetailResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 
 @Getter
 public class GatheringDetailResponse {
@@ -26,7 +27,9 @@ public class GatheringDetailResponse {
     private final Long likes;
     private final Long views;
     private final boolean isOwner;
+    private final boolean isLiked;
     private final AuthorResponse author;
+    private final List<String> photos;
 
     @Builder
     private GatheringDetailResponse(
@@ -45,7 +48,9 @@ public class GatheringDetailResponse {
         String userNickname,
         Long likes,
         boolean isOwner,
-        AuthorResponse author
+        boolean isLiked,
+        AuthorResponse author,
+        List<String> photos
     ) {
         this.id = id;
         this.title = title;
@@ -62,7 +67,9 @@ public class GatheringDetailResponse {
         this.userNickname = userNickname;
         this.likes = likes;
         this.isOwner = isOwner;
+        this.isLiked = isLiked;
         this.author = author;
+        this.photos = photos;
     }
 
     public static GatheringDetailResponse from(GatheringDetailInfo gatheringInfo) {
@@ -82,6 +89,7 @@ public class GatheringDetailResponse {
                                       .userNickname(gatheringInfo.getUser().getNickname())
                                       .likes(gatheringInfo.getLikes())
                                       .isOwner(gatheringInfo.isOwner())
+                                      .isLiked(gatheringInfo.isLiked())
                                       .author(AuthorResponse.from(gatheringInfo))
                                       .build();
     }

--- a/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringDetailResponse.java
+++ b/src/main/java/com/develop_ping/union/gathering/presentation/dto/response/GatheringDetailResponse.java
@@ -22,7 +22,6 @@ public class GatheringDetailResponse {
     private final Double longitude;
     private final String eupMyeonDong;
     private final ZonedDateTime gatheringDateTime;
-    private final String userNickname;
     private final ZonedDateTime createdAt;
     private final Long likes;
     private final Long views;
@@ -47,7 +46,6 @@ public class GatheringDetailResponse {
         ZonedDateTime gatheringDateTime,
         Long views,
         ZonedDateTime createdAt,
-        String userNickname,
         Long likes,
         boolean isOwner,
         boolean isLiked,
@@ -68,7 +66,6 @@ public class GatheringDetailResponse {
         this.gatheringDateTime = gatheringDateTime;
         this.views = views;
         this.createdAt = createdAt;
-        this.userNickname = userNickname;
         this.likes = likes;
         this.isOwner = isOwner;
         this.isLiked = isLiked;
@@ -92,7 +89,6 @@ public class GatheringDetailResponse {
                                       .gatheringDateTime(gatheringDetailInfo.getGatheringInfo().getGatheringDateTime())
                                       .views(gatheringDetailInfo.getGatheringInfo().getViews())
                                       .createdAt(gatheringDetailInfo.getGatheringInfo().getCreatedAt())
-                                      .userNickname(gatheringDetailInfo.getUser().getNickname())
                                       .likes(gatheringDetailInfo.getLikes())
                                       .isOwner(gatheringDetailInfo.isOwner())
                                       .isLiked(gatheringDetailInfo.isLiked())
@@ -125,7 +121,7 @@ public class GatheringDetailResponse {
         public static GatheringDetailResponse.AuthorResponse from(GatheringDetailInfo info) {
             return AuthorResponse.builder()
                                  .token(info.getUser().getToken())
-                                 .nickname(info.getUser().getUnivName())
+                                 .nickname(info.getUser().getNickname())
                                  .profileImage(info.getUser().getProfileImage())
                                  .univName(info.getUser().getUnivName())
                                  .build();

--- a/src/main/java/com/develop_ping/union/party/domain/PartyManager.java
+++ b/src/main/java/com/develop_ping/union/party/domain/PartyManager.java
@@ -3,6 +3,7 @@ package com.develop_ping.union.party.domain;
 import com.develop_ping.union.gathering.domain.entity.Gathering;
 import com.develop_ping.union.party.domain.dto.PartyInfo;
 import com.develop_ping.union.party.domain.entity.Party;
+import com.develop_ping.union.party.domain.entity.PartyRole;
 import com.develop_ping.union.user.domain.entity.User;
 
 import java.util.Optional;
@@ -12,12 +13,9 @@ public interface PartyManager {
     PartyInfo createParty(Gathering gathering, User user);
     boolean existsByGatheringAndUser(Gathering gathering, User user);
 
-    // 모임 참여자 삭제 - 나가기 기능
-    void exitGathering(Gathering gathering, User user);
-
-    Party findOwnerByGathering(Long gatheringId);
-
     Optional<Party> findByGatheringAndUser(Gathering gathering, User user);
 
     void save(Party party);
+
+    Party findOwnerByGatheringIdAndRole(Long gatheringId, PartyRole partyRole);
 }

--- a/src/main/java/com/develop_ping/union/party/domain/PartyManager.java
+++ b/src/main/java/com/develop_ping/union/party/domain/PartyManager.java
@@ -3,27 +3,21 @@ package com.develop_ping.union.party.domain;
 import com.develop_ping.union.gathering.domain.entity.Gathering;
 import com.develop_ping.union.party.domain.dto.PartyInfo;
 import com.develop_ping.union.party.domain.entity.Party;
-import com.develop_ping.union.party.domain.entity.PartyRole;
 import com.develop_ping.union.user.domain.entity.User;
+
+import java.util.Optional;
 
 public interface PartyManager {
 
     PartyInfo createParty(Gathering gathering, User user);
-    Party findByGatheringAndUser(Gathering gathering, User user);
-    void deleteParty(Gathering gathering);
-    void joinGathering(Gathering gathering, User user);
-
-    // 주최자 닉네임 가져오기
-    String findOwnerNicknameByGathering(Gathering gathering);
-
-    // 주최자인지 여부 확인
-    boolean existsByGatheringAndUserAndRole(Gathering gathering, User user, PartyRole role);
-
-    // 모임 참여 여부 확인
     boolean existsByGatheringAndUser(Gathering gathering, User user);
 
     // 모임 참여자 삭제 - 나가기 기능
-    void deleteByGatheringAndUser(Gathering gathering, User user);
+    void exitGathering(Gathering gathering, User user);
 
-    void delete(Party party);
+    Party findOwnerByGathering(Long gatheringId);
+
+    Optional<Party> findByGatheringAndUser(Gathering gathering, User user);
+
+    void save(Party party);
 }

--- a/src/main/java/com/develop_ping/union/party/domain/entity/Party.java
+++ b/src/main/java/com/develop_ping/union/party/domain/entity/Party.java
@@ -5,7 +5,6 @@ import com.develop_ping.union.gathering.domain.entity.Gathering;
 import com.develop_ping.union.user.domain.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.boot.model.internal.ForeignKeyType;
 
 @Getter
 @Entity

--- a/src/main/java/com/develop_ping/union/party/infra/PartyManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/party/infra/PartyManagerImpl.java
@@ -8,7 +8,6 @@ import com.develop_ping.union.party.domain.dto.PartyInfo;
 import com.develop_ping.union.party.domain.entity.Party;
 import com.develop_ping.union.party.domain.entity.PartyRole;
 import com.develop_ping.union.party.exception.AlreadyJoinedException;
-import com.develop_ping.union.party.exception.ParticipationNotFoundException;
 import com.develop_ping.union.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +19,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Slf4j
 public class PartyManagerImpl implements PartyManager {
- private final PartyRepository partyRepository;
+
+    private final PartyRepository partyRepository;
 
     @Override
     public PartyInfo createParty(Gathering gathering, User user) {
@@ -40,22 +40,6 @@ public class PartyManagerImpl implements PartyManager {
     }
 
     @Override
-    public void exitGathering(Gathering gathering, User user) {
-        log.info("\n모임 참여자 삭제 - 나가기 기능 PartyManagerImpl 클래스 : gathering: {}, user: {}", gathering.getId(), user.getId());
-
-        partyRepository.findByGatheringAndUser(gathering, user)
-                                    .orElseThrow(() -> new ParticipationNotFoundException("참여 정보가 없습니다."));
-
-        partyRepository.deleteByGatheringAndUser(gathering, user);
-    }
-
-    @Override
-    public Party findOwnerByGathering(Long gatheringId) {
-        return partyRepository.findByGatheringId(gatheringId)
-                              .orElseThrow(() -> new GatheringNotFoundException(gatheringId));
-    }
-
-    @Override
     public Optional<Party> findByGatheringAndUser(Gathering gathering, User user) {
         return partyRepository.findByGatheringAndUser(gathering, user);
     }
@@ -65,14 +49,9 @@ public class PartyManagerImpl implements PartyManager {
         partyRepository.save(party);
     }
 
-    // TODO: 도메인 로직으로 이동 고려
-    private void validateJoinConditions(Gathering gathering, User user) {
-        if (partyRepository.existsByGatheringAndUser(gathering, user)) {
-            throw new AlreadyJoinedException("이미 해당 모임에 참여하셨습니다.");
-        }
-
-        if (gathering.getCurrentMember() > gathering.getMaxMember()) {
-            throw new ParticipantLimitExceededException("모임 인원이 가득 찼습니다.");
-        }
+    @Override
+    public Party findOwnerByGatheringIdAndRole(Long gatheringId, PartyRole partyRole) {
+        return partyRepository.findByGatheringIdAndRole(gatheringId, partyRole)
+                              .orElseThrow(() -> new GatheringNotFoundException(gatheringId));
     }
 }

--- a/src/main/java/com/develop_ping/union/party/infra/PartyRepository.java
+++ b/src/main/java/com/develop_ping/union/party/infra/PartyRepository.java
@@ -13,19 +13,6 @@ import java.util.Optional;
 public interface PartyRepository extends JpaRepository<Party, Long> {
 
     Optional<Party> findByGatheringAndUser(Gathering gathering, User user);
-    Optional<Party> findByGathering(Gathering gathering);
-    void deleteByGathering(Gathering gathering);
     boolean existsByGatheringAndUser(Gathering gathering, User user);
-
-    // 주최자 닉네임을 Gathering과 Role 기준으로 조회
-    @Query("SELECT u.nickname FROM Party p JOIN p.user u WHERE p.gathering = :gathering AND p.role = :role")
-    String findOwnerNicknameByGatheringAndRole(@Param("gathering") Gathering gathering, @Param("role") PartyRole role);
-
-    // 주최자 여부 확인
-    boolean existsByGatheringAndUserAndRole(Gathering gathering, User user, PartyRole role);
-
-    // 모임 참여자 삭제 - 나가기 기능
-    void deleteByGatheringAndUser(Gathering gathering, User user);
-
-    Optional<Party> findByGatheringId(Long gatheringId);
+    Optional<Party> findByGatheringIdAndRole(Long gatheringId, PartyRole partyRole);
 }

--- a/src/main/java/com/develop_ping/union/party/infra/PartyRepository.java
+++ b/src/main/java/com/develop_ping/union/party/infra/PartyRepository.java
@@ -26,4 +26,6 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
 
     // 모임 참여자 삭제 - 나가기 기능
     void deleteByGatheringAndUser(Gathering gathering, User user);
+
+    Optional<Party> findByGatheringId(Long gatheringId);
 }

--- a/src/main/java/com/develop_ping/union/reaction/domain/ReactionManager.java
+++ b/src/main/java/com/develop_ping/union/reaction/domain/ReactionManager.java
@@ -1,6 +1,10 @@
 package com.develop_ping.union.reaction.domain;
 
+import com.develop_ping.union.reaction.domain.entity.ReactionType;
+
 public interface ReactionManager {
 
     Long selectLikeCount(Long gatheringId);
+
+    boolean existsByUserIdAndTypeAndId(Long userId, ReactionType type, Long gatheringId);
 }

--- a/src/main/java/com/develop_ping/union/reaction/infra/ReactionManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/reaction/infra/ReactionManagerImpl.java
@@ -15,4 +15,9 @@ public class ReactionManagerImpl implements ReactionManager {
     public Long selectLikeCount(Long gatheringId) {
         return reactionRepository.countByTypeAndGatheringId(ReactionType.GATHERING, gatheringId);
     }
+
+    @Override
+    public boolean existsByUserIdAndTypeAndId(Long userId, ReactionType type, Long gatheringId) {
+        return reactionRepository.existsByUserIdAndTypeAndId(userId, type, gatheringId);
+    }
 }

--- a/src/main/java/com/develop_ping/union/reaction/infra/ReactionRepository.java
+++ b/src/main/java/com/develop_ping/union/reaction/infra/ReactionRepository.java
@@ -10,4 +10,6 @@ public interface ReactionRepository extends JpaRepository<Reaction, Long> {
 
     @Query("SELECT COUNT(r) FROM Reaction r WHERE r.type = :type AND r.userId = :gatheringId")
     long countByTypeAndGatheringId(@Param("type") ReactionType type, @Param("gatheringId") Long gatheringId);
+
+    boolean existsByUserIdAndTypeAndId(Long userId, ReactionType type, Long gatheringId);
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,29 +2,29 @@
 INSERT INTO gatherings
 (
     current_member, latitude, longitude, views, max_member, created_at, gathering_date_time,
-    updated_at, address, content, title, eup_myeon_dong
+    updated_at, address, content, title, eup_myeon_dong, recruited
 )
 VALUES
     (5, 37.5665, 126.9780, 10, 10, DATE_SUB(NOW(), INTERVAL 9 HOUR), DATE_ADD(NOW(), INTERVAL 1 HOUR),
-     NOW(), '서울 중구 명동', '첫 번째 모임 설명', '첫 번째 모임', '명동'),
+     NOW(), '서울 중구 명동', '첫 번째 모임 설명', '첫 번째 모임', '명동', false),
     (2, 36.3504, 127.3845, 100, 5, DATE_SUB(NOW(), INTERVAL 8 HOUR), DATE_ADD(NOW(), INTERVAL 2 HOUR),
-     NOW(), '대전 서구 둔산동', '두 번째 모임 설명', '두 번째 모임', '둔산동'),
+     NOW(), '대전 서구 둔산동', '두 번째 모임 설명', '두 번째 모임', '둔산동', false),
     (8, 35.8722, 128.6025, 1, 20, DATE_SUB(NOW(), INTERVAL 7 HOUR), DATE_ADD(NOW(), INTERVAL 3 HOUR),
-     NOW(), '대구 수성구 수성동', '세 번째 모임 설명', '세 번째 모임', '수성동'),
+     NOW(), '대구 수성구 수성동', '세 번째 모임 설명', '세 번째 모임', '수성동', false),
     (3, 35.1796, 129.0756, 5, 15, DATE_SUB(NOW(), INTERVAL 6 HOUR), DATE_ADD(NOW(), INTERVAL 4 HOUR),
-     NOW(), '부산 해운대구 해운대해변로', '네 번째 모임 설명', '네 번째 모임', '해운대동'),
+     NOW(), '부산 해운대구 해운대해변로', '네 번째 모임 설명', '네 번째 모임', '해운대동', true),
     (1, 35.1595, 126.8526, 2, 4, DATE_SUB(NOW(), INTERVAL 5 HOUR), DATE_ADD(NOW(), INTERVAL 5 HOUR),
-     NOW(), '광주 북구 용봉동', '다섯 번째 모임 설명', '다섯 번째 모임', '용봉동'),
+     NOW(), '광주 북구 용봉동', '다섯 번째 모임 설명', '다섯 번째 모임', '용봉동', true),
     (6, 35.5384, 129.3114, 15, 12, DATE_SUB(NOW(), INTERVAL 4 HOUR), DATE_ADD(NOW(), INTERVAL 6 HOUR),
-     NOW(), '울산 남구 삼산동', '여섯 번째 모임 설명', '여섯 번째 모임', '삼산동'),
+     NOW(), '울산 남구 삼산동', '여섯 번째 모임 설명', '여섯 번째 모임', '삼산동', false),
     (4, 33.4996, 126.5312, 22, 8, DATE_SUB(NOW(), INTERVAL 3 HOUR), DATE_ADD(NOW(), INTERVAL 7 HOUR),
-     NOW(), '제주 제주시 연동', '일곱 번째 모임 설명', '일곱 번째 모임', '연동'),
+     NOW(), '제주 제주시 연동', '일곱 번째 모임 설명', '일곱 번째 모임', '연동', true),
     (7, 37.4563, 126.7052, 0, 10, DATE_SUB(NOW(), INTERVAL 2 HOUR), DATE_ADD(NOW(), INTERVAL 8 HOUR),
-     NOW(), '인천 중구 을왕동', '여덟 번째 모임 설명', '여덟 번째 모임', '을왕동'),
+     NOW(), '인천 중구 을왕동', '여덟 번째 모임 설명', '여덟 번째 모임', '을왕동', true),
     (2, 37.2751, 127.0097, 1, 6, DATE_SUB(NOW(), INTERVAL 1 HOUR), DATE_ADD(NOW(), INTERVAL 9 HOUR),
-     NOW(), '경기 성남시 분당구', '아홉 번째 모임 설명', '아홉 번째 모임', '분당동'),
+     NOW(), '경기 성남시 분당구', '아홉 번째 모임 설명', '아홉 번째 모임', '분당동', false),
     (9, 35.1798, 128.1076, 7, 20, NOW(), DATE_ADD(NOW(), INTERVAL 10 HOUR),
-     NOW(), '경남 김해시 내외동', '열 번째 모임 설명', '열 번째 모임', '내외동');
+     NOW(), '경남 김해시 내외동', '열 번째 모임 설명', '열 번째 모임', '내외동', false);
 
 -- 파티 더미 데이터
 INSERT INTO parties (gathering_id, user_id, role, created_at, updated_at)


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #110 

## 📝 작업 내용
- 모임 상태 확인을 위한 필드 추가 (`모집 중`, `모집 완료`)
- 모임 상세 보기 시 `모임 참여 여부`,`모임 모집 완료 여부`,`내가 좋아요 한 여부`,`작성자 정보`, `사진` 추가

## 🎸 기타 (선택)
> 고려해야 하는 내용을 작성해 주세요.
- 현재 `모임 참여하기`, `모임 나가기` 기능 둘 모두 비관적 락(`FOR UPDATE`)이 적용되어 있어,
  모임에 참가된 유저가 `모임 나가기` 기능을 실행하고, 다른 유저가 `모임 참여하기` 했을 때 락을 많이 기다리게 돼서 성능 이슈가 발생할 수 있음.

락 대기 시나리오
```sql
-- session 1 (모임 참가)

-- 트랜잭션 시작
BEGIN;

-- 모임에 대해 비관적 락 걸기 (참가자 수 증가를 위해)
BEGIN;
SELECT current_member, max_member
FROM gatherings
WHERE id = 1
for UPDATE;

-- 참가자 추가
INSERT INTO parties (gathering_id, user_id, role, created_at, updated_at)
VALUES (1, 101, 'PARTICIPANT', NOW(), NOW());

-- 참가자 수 증가
UPDATE gatherings
SET current_member = current_member + 1
WHERE id = 1;

-- 트랜잭션 커밋하지 않고 대기 (참가 시도 중)
```

```sql
-- session 2 (모임 나가기)
SELECT current_member
FROM gatherings
WHERE id = 1
FOR UPDATE;

-- session 1이 락을 잡고 있기 때문에 session 2는 대기 session 1의 작업이 끝날 때 까지 대기
```

## 💬 리뷰 요구사항(선택)
