### PR TITLE
feat: 특정 유저의 모임글 리스트 조회 API (#123), N + 1 문제

### DIFF
--- a/src/main/java/com/develop_ping/union/gathering/domain/GatheringManager.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/GatheringManager.java
@@ -18,6 +18,8 @@ public interface GatheringManager {
 
     Slice<Gathering> getMyGatheringList(User user, Pageable pageable);
 
+    Slice<Gathering> getUserGatheringList(String userToken, Pageable pageable);
+
     // 유저 탈퇴시
     //  이 유저가 가입된 모임 목록을 조회
     //    유저의 권한이 회원 (파티 나가기)

--- a/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringService.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringService.java
@@ -20,4 +20,6 @@ public interface GatheringService {
     void exitGathering(Long gatheringId, User user);
 
     Slice<GatheringListInfo> getMyGatheringList(User user, Pageable pageable);
+
+    Slice<GatheringListInfo> getUserGatheringList(String userToken, Pageable pageable);
 }

--- a/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/gathering/domain/service/GatheringServiceImpl.java
@@ -187,4 +187,12 @@ public class GatheringServiceImpl implements GatheringService {
         Slice<Gathering> gatheringList = gatheringManager.getMyGatheringList(user, pageable);
         return GatheringListInfo.of(gatheringList);
     }
+
+    @Override
+    public Slice<GatheringListInfo> getUserGatheringList(String userToken, Pageable pageable) {
+        log.info("\n특정 사용자의 모임 리스트 조회 getUserGatheringList ServiceImpl 클래스 : userToken {}, pageable {}", userToken, pageable);
+
+        Slice<Gathering> gatheringList = gatheringManager.getUserGatheringList(userToken, pageable);
+        return GatheringListInfo.of(gatheringList);
+    }
 }

--- a/src/main/java/com/develop_ping/union/gathering/infra/GatheringManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/gathering/infra/GatheringManagerImpl.java
@@ -10,6 +10,7 @@ import com.develop_ping.union.gathering.exception.GatheringNotFoundException;
 import com.develop_ping.union.party.domain.PartyManager;
 import com.develop_ping.union.party.domain.entity.Party;
 import com.develop_ping.union.party.domain.entity.PartyRole;
+import com.develop_ping.union.user.domain.UserManager;
 import com.develop_ping.union.user.domain.entity.User;
 import com.develop_ping.union.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class GatheringManagerImpl implements GatheringManager {
 
     private final GatheringRepository gatheringRepository;
     private final PartyManager partyManager;
+    private final UserManager userManager;
 
     @Override
     public GatheringInfo save(Gathering gathering) {
@@ -79,5 +81,15 @@ public class GatheringManagerImpl implements GatheringManager {
         log.info("\n내가 작성한 모임 리스트 조회 ManagerImpl 클래스 : {}", user.getId());
 
         return gatheringRepository.findByUserAsOwner(user, pageable);
+    }
+
+    @Override
+    public Slice<Gathering> getUserGatheringList(String userToken, Pageable pageable) {
+        log.info("\n특정 사용자의 모임 리스트 조회 ManagerImpl 클래스 : {}", userToken);
+
+        User findByTokenUserResult = userManager.findByToken(userToken);
+        log.info("\n사용자 토큰으로 유저 조회 완료 : User: {}", findByTokenUserResult);
+
+        return gatheringRepository.findByUserAsOwner(findByTokenUserResult, pageable);
     }
 }

--- a/src/main/java/com/develop_ping/union/gathering/infra/GatheringRepository.java
+++ b/src/main/java/com/develop_ping/union/gathering/infra/GatheringRepository.java
@@ -78,8 +78,9 @@ public interface GatheringRepository extends JpaRepository<Gathering, Long> {
     @Query("SELECT g FROM Gathering g WHERE g.id = :gatheringId")
     Optional<Gathering> findWithPessimisticLockById(@Param("gatheringId") Long gatheringId);
 
+    // FETCH JOIN을 이용하여 모임 게시글과 파티 정보를 함께 조회(N + 1 문제 해결)
     @Query("""
-    SELECT g FROM Gathering g JOIN g.parties p
+    SELECT g FROM Gathering g JOIN FETCH g.parties p
     WHERE p.user = :user AND p.role = 'owner' ORDER BY g.id DESC
     """)
     Slice<Gathering> findByUserAsOwner(@Param("user") User user, Pageable pageable);

--- a/src/main/java/com/develop_ping/union/gathering/presentation/GatheringController.java
+++ b/src/main/java/com/develop_ping/union/gathering/presentation/GatheringController.java
@@ -127,4 +127,17 @@ public class GatheringController {
 
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/user/{userToken}")
+    public ResponseEntity<Slice<GatheringListResponse>> getUserGatheringList(
+        @PathVariable("userToken") String userToken,
+        @PageableDefault(size = 5) Pageable pageable
+    ) {
+        log.info("특정 사용자의 모임 리스트 조회 요청 - userToken: {}, pageable: {}", userToken, pageable);
+
+        Slice<GatheringListInfo> gatheringList = gatheringService.getUserGatheringList(userToken, pageable);
+        Slice<GatheringListResponse> response = gatheringList.map(GatheringListResponse::from);
+
+        return ResponseEntity.ok(response);
+    }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #123 

## 📝 작업 내용
- 유저 토큰으로 해당 유저의 모임글 목록을 보는 API
- 이때 발생하는 N + 1 문제 해결 

## 🎸 기타 (선택)
- 모임 나가기 시 발생하는 N + 1 문제도 해결 해보자. (일단 fetch join 만이라도..?)
- 나중에 batch size를 사용해야 될 일이 있을수도?

## 💬 리뷰 요구사항(선택)
