### PR TITLE
fix: 댓글 is Liked 로직 수정

### DIFF
--- a/src/main/java/com/develop_ping/union/comment/domain/service/CommentServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/service/CommentServiceImpl.java
@@ -95,7 +95,7 @@ public class CommentServiceImpl implements CommentService {
         return comments.stream().map(comment -> {
             long commentLikes = reactionManager.countLikesByComment(comment.getId());
             boolean isLiked = reactionManager.existsByUserIdAndTypeAndId(
-                    comment.getUser().getId(),
+                    command.getUser().getId(),
                     ReactionType.COMMENT,
                     comment.getId());
 


### PR DESCRIPTION
## ⚡️ 관련 이슈

> 

## 📝 작업 내용

> 다른 사람의 댓글에 좋아요를 눌렀을 때 `isLiked` 필드가 false가 뜨는 버그를 수정하였습니다.

## 🎸 기타 (선택)
> 

## 💬 리뷰 요구사항(선택)

> 
