### PR TITLE
feat: 유저 활동 정보 조회 API 구현(#140)

### DIFF
--- a/src/main/java/com/develop_ping/union/party/domain/PartyManager.java
+++ b/src/main/java/com/develop_ping/union/party/domain/PartyManager.java
@@ -26,4 +26,6 @@ public interface PartyManager {
     List<Party> findByUserId(Long userId);
 
     Party findByGatheringIdAndUserID(Long gatheringId, Long userId);
+
+    long countByUserIdAndRole(Long userId);
 }

--- a/src/main/java/com/develop_ping/union/party/infra/PartyManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/party/infra/PartyManagerImpl.java
@@ -11,6 +11,7 @@ import com.develop_ping.union.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
@@ -84,5 +85,11 @@ public class PartyManagerImpl implements PartyManager {
     public Party findByGatheringIdAndUserID(Long gatheringId, Long userId) {
         return partyRepository.findByGatheringIdAndUserId(gatheringId, userId)
                               .orElseThrow(() -> new GatheringPermissionDeniedException(gatheringId, userId));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countByUserIdAndRole(Long userId) {
+        return partyRepository.countByUserIdAndRole(userId, PartyRole.OWNER);
     }
 }

--- a/src/main/java/com/develop_ping/union/party/infra/PartyRepository.java
+++ b/src/main/java/com/develop_ping/union/party/infra/PartyRepository.java
@@ -20,4 +20,6 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
     Optional<Party> findByGatheringIdAndUserId(Long gatheringId, Long userId);
 
     List<Party> findByGatheringId(Long gatheringId);
+
+    long countByUserIdAndRole(Long userId, PartyRole partyRole);
 }

--- a/src/main/java/com/develop_ping/union/post/domain/PostManager.java
+++ b/src/main/java/com/develop_ping/union/post/domain/PostManager.java
@@ -18,4 +18,6 @@ public interface PostManager {
     Page<Post> searchByTypeAndKeyword(PostType type, String keyword, Pageable pageable);
     Page<Post> searchByKeyword(String keyword, Pageable pageable);
     Page<Post> findPopularPosts(Pageable pageable);
+    long countByUserId(Long userId);
+    long countPostsByUserComments(Long userId);
 }

--- a/src/main/java/com/develop_ping/union/post/infra/PostManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/post/infra/PostManagerImpl.java
@@ -84,4 +84,16 @@ public class PostManagerImpl implements PostManager {
     public Page<Post> findPopularPosts(Pageable pageable) {
         return postRepository.findPopularPosts(ReactionType.POST, POPULAR_POST_REACTION_COUNT, pageable);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countByUserId(Long userId) {
+        return postRepository.countByUserId(userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countPostsByUserComments(Long userId) {
+        return postRepository.countPostsByUserComments(userId);
+    }
 }

--- a/src/main/java/com/develop_ping/union/post/infra/PostRepository.java
+++ b/src/main/java/com/develop_ping/union/post/infra/PostRepository.java
@@ -21,9 +21,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findPostsByUserComments(@Param("user") User user, Pageable pageable);
 
     @Query("""
-            SELECT p FROM Post p 
-            WHERE p.type = :type 
-              AND (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) 
+            SELECT p FROM Post p
+            WHERE p.type = :type
+              AND (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                 OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')))
     """)
     Page<Post> searchByTypeAndKeyword(
@@ -32,8 +32,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             Pageable pageable);
 
     @Query("""
-            SELECT p FROM Post p 
-            WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) 
+            SELECT p FROM Post p
+            WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%'))
     """)
     Page<Post> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
@@ -48,4 +48,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findPopularPosts(@Param("reactionType") ReactionType reactionType,
                                 @Param("minLikes") long minLikes,
                                 Pageable pageable);
+
+    long countByUserId(Long userId);
+
+    @Query("SELECT COUNT(DISTINCT p) FROM Post p JOIN p.comments c WHERE c.user.id = :userId")
+    long countPostsByUserComments(@Param("userId") Long userId);
 }

--- a/src/main/java/com/develop_ping/union/user/domain/dto/UserStatCommand.java
+++ b/src/main/java/com/develop_ping/union/user/domain/dto/UserStatCommand.java
@@ -1,0 +1,24 @@
+package com.develop_ping.union.user.domain.dto;
+
+import com.develop_ping.union.user.domain.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserStatCommand {
+    private String userToken;
+    private User user;
+
+    @Builder
+    private UserStatCommand(String userToken, User user) {
+        this.userToken = userToken;
+        this.user = user;
+    }
+
+    public static UserStatCommand of(String userToken, User user) {
+        return UserStatCommand.builder()
+                .userToken(userToken)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/develop_ping/union/user/domain/dto/UserStatInfo.java
+++ b/src/main/java/com/develop_ping/union/user/domain/dto/UserStatInfo.java
@@ -1,0 +1,26 @@
+package com.develop_ping.union.user.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserStatInfo {
+    private final long postCount;
+    private final long commentCount;
+    private final long gatheringCount;
+
+    @Builder
+    private UserStatInfo(long postCount, long commentCount, long gatheringCount) {
+        this.postCount = postCount;
+        this.commentCount = commentCount;
+        this.gatheringCount = gatheringCount;
+    }
+
+    public static UserStatInfo of(long postCount, long commentCount, long gatheringCount) {
+        return UserStatInfo.builder()
+                .postCount(postCount)
+                .commentCount(commentCount)
+                .gatheringCount(gatheringCount)
+                .build();
+    }
+}

--- a/src/main/java/com/develop_ping/union/user/domain/service/UserService.java
+++ b/src/main/java/com/develop_ping/union/user/domain/service/UserService.java
@@ -2,6 +2,8 @@ package com.develop_ping.union.user.domain.service;
 
 import com.develop_ping.union.user.domain.dto.UserCommand;
 import com.develop_ping.union.user.domain.dto.UserInfo;
+import com.develop_ping.union.user.domain.dto.UserStatCommand;
+import com.develop_ping.union.user.domain.dto.UserStatInfo;
 import com.develop_ping.union.user.domain.entity.User;
 
 import java.util.List;
@@ -20,4 +22,6 @@ public interface UserService {
     void unblockUser(User user, String userToken);
 
     List<UserInfo> readBlockedUsers (User user);
+
+    UserStatInfo readUserStat(UserStatCommand command);
 }

--- a/src/main/java/com/develop_ping/union/user/presentation/UserController.java
+++ b/src/main/java/com/develop_ping/union/user/presentation/UserController.java
@@ -1,12 +1,15 @@
 package com.develop_ping.union.user.presentation;
 
 import com.develop_ping.union.user.domain.dto.UserInfo;
+import com.develop_ping.union.user.domain.dto.UserStatCommand;
+import com.develop_ping.union.user.domain.dto.UserStatInfo;
 import com.develop_ping.union.user.domain.entity.User;
 import com.develop_ping.union.user.domain.service.UserService;
 import com.develop_ping.union.user.presentation.dto.request.RegisterRequest;
 import com.develop_ping.union.user.presentation.dto.request.UpdateRequest;
 import com.develop_ping.union.user.presentation.dto.response.OtherUserResponse;
 import com.develop_ping.union.user.presentation.dto.response.UserResponse;
+import com.develop_ping.union.user.presentation.dto.response.UserStatResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -99,5 +102,17 @@ public class UserController {
     @GetMapping("/my")
     public ResponseEntity<UserResponse> readUserStatus (@AuthenticationPrincipal User user) {
         return ResponseEntity.ok(UserResponse.from(user));
+    }
+
+    @GetMapping("/stats/{userToken}")
+    public ResponseEntity<UserStatResponse> readUserStat(@PathVariable String userToken,
+                                                         @AuthenticationPrincipal User user) {
+        log.info("[ CALL: UserController.readUserStat() ] with user token: {}", userToken);
+
+        UserStatCommand command = UserStatCommand.of(userToken, user);
+        UserStatInfo info = userService.readUserStat(command);
+        UserStatResponse response = UserStatResponse.from(info);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/develop_ping/union/user/presentation/dto/response/UserStatResponse.java
+++ b/src/main/java/com/develop_ping/union/user/presentation/dto/response/UserStatResponse.java
@@ -1,0 +1,30 @@
+package com.develop_ping.union.user.presentation.dto.response;
+
+import com.develop_ping.union.user.domain.dto.UserStatInfo;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserStatResponse {
+    private long postCount;
+    private long commentCount;
+    private long gatheringCount;
+
+    @Builder
+    private UserStatResponse(long postCount, long commentCount, long gatheringCount) {
+        this.postCount = postCount;
+        this.commentCount = commentCount;
+        this.gatheringCount = gatheringCount;
+    }
+
+    public static UserStatResponse from(UserStatInfo info) {
+        return UserStatResponse.builder()
+                .postCount(info.getPostCount())
+                .commentCount(info.getCommentCount())
+                .gatheringCount(info.getGatheringCount())
+                .build();
+    }
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈

> close #140 

## 📝 작업 내용

> 유저 토큰으로 해당 유저의 활동 정보를 조회합니다.
> `작성한 게시글`, `댓글 단 게시글`, `작성한 모임글`의 갯수를 반환합니다.

## 🎸 기타 (선택)
> 

## 💬 리뷰 요구사항(선택)

> 
