### PR TITLE
Feat/#150 block filter posts and comments

### DIFF
--- a/src/main/java/com/develop_ping/union/comment/domain/dto/CommentInfo.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/dto/CommentInfo.java
@@ -15,11 +15,12 @@ public class CommentInfo {
     private final String parentNickname;
     private final ZonedDateTime createdAt;
     private final long commentLikes;
-    private final boolean isLiked;
+    private final boolean liked;
     private final String token;
     private final String nickname;
     private final String profileImage;
     private final String univName;
+    private final boolean deleted;
 
     @Builder
     private CommentInfo(Long id,
@@ -29,11 +30,12 @@ public class CommentInfo {
                         String parentNickname,
                         ZonedDateTime createdAt,
                         long commentLikes,
-                        boolean isLiked,
+                        boolean liked,
                         String token,
                         String nickname,
                         String profileImage,
-                        String univName) {
+                        String univName,
+                        boolean deleted) {
         this.id = id;
         this.content = content;
         this.postId = postId;
@@ -41,11 +43,12 @@ public class CommentInfo {
         this.parentNickname = parentNickname;
         this.createdAt = createdAt;
         this.commentLikes = commentLikes;
-        this.isLiked = isLiked;
+        this.liked = liked;
         this.token = token;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.univName = univName;
+        this.deleted = deleted;
     }
 
     public static CommentInfo from(Comment comment) {
@@ -54,7 +57,7 @@ public class CommentInfo {
                 .build();
     }
 
-    public static CommentInfo of(Comment comment, long commentLikes, boolean isLiked) {
+    public static CommentInfo of(Comment comment, long commentLikes, boolean liked) {
         if (comment == null) { return null; }
 
         CommentInfo.CommentInfoBuilder builder = CommentInfo.builder()
@@ -64,13 +67,32 @@ public class CommentInfo {
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
                 .parentNickname(comment.getParentNickname() != null ? comment.getParentNickname() : null)
                 .commentLikes(commentLikes)
-                .isLiked(isLiked)
+                .liked(liked)
                 .createdAt(comment.getCreatedAt())
                 .token(comment.getUser().getToken())
                 .nickname(comment.getUser().getNickname())
                 .profileImage(comment.getUser().getProfileImage())
-                .univName(comment.getUser().getUnivName());
+                .univName(comment.getUser().getUnivName())
+                .deleted(comment.isDeleted());
 
         return builder.build();
+    }
+
+    public static CommentInfo blockedFrom(Comment comment) {
+        return CommentInfo.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .postId(comment.getPost().getId())
+                .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+                .parentNickname(comment.getParentNickname() != null ? comment.getParentNickname() : null)
+                .commentLikes(0)
+                .liked(false)
+                .createdAt(comment.getCreatedAt())
+                .token(comment.getUser().getToken())
+                .nickname(comment.getUser().getNickname())
+                .profileImage(comment.getUser().getProfileImage())
+                .univName(comment.getUser().getUnivName())
+                .deleted(true)
+                .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/domain/dto/CommentReactionInfo.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/dto/CommentReactionInfo.java
@@ -6,18 +6,18 @@ import lombok.Getter;
 @Getter
 public class CommentReactionInfo {
     private final long commentLikes;
-    private final boolean isLiked;
+    private final boolean liked;
 
     @Builder
-    private CommentReactionInfo(long commentLikes, boolean isLiked) {
+    private CommentReactionInfo(long commentLikes, boolean liked) {
         this.commentLikes = commentLikes;
-        this.isLiked = isLiked;
+        this.liked = liked;
     }
 
-    public static CommentReactionInfo of(long commentLikes, boolean isLiked) {
+    public static CommentReactionInfo of(long commentLikes, boolean liked) {
         return CommentReactionInfo.builder()
                 .commentLikes(commentLikes)
-                .isLiked(isLiked)
+                .liked(liked)
                 .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/domain/entity/Comment.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/entity/Comment.java
@@ -18,8 +18,6 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "comments")
 public class Comment extends AuditingFields {
-    // TODO: deletedAt 필드 추가해서 삭제된 댓글 표시하기
-
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -42,8 +40,12 @@ public class Comment extends AuditingFields {
     @Column(nullable = true)
     private String parentNickname;
 
-    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL) // 지금은 부모 댓글 삭제되면 전체 삭제하기
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OrderBy("createdAt ASC")
     private List<Comment> children = new ArrayList<>();
+
+    @Column(nullable = false)
+    private boolean deleted;
 
     @Builder
     private Comment(String content,
@@ -74,5 +76,13 @@ public class Comment extends AuditingFields {
 
     public void updateContent(String content) {
         this.content = content;
+    }
+
+    public void softDelete() {
+        this.deleted = true;
+    }
+
+    public boolean isDeleted() {
+        return this.deleted;
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/infra/CommentManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/comment/infra/CommentManagerImpl.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 public class CommentManagerImpl implements CommentManager {
     private final CommentRepository commentRepository;
 
+    private final static long BEST_COMMENT_REACTION_COUNT = 2;
+
     @Override
     @Transactional
     public Comment save(Comment comment) {
@@ -50,7 +52,10 @@ public class CommentManagerImpl implements CommentManager {
 
     @Override
     public Comment findBestComment(Long postId) {
-        Optional<Comment> comment = commentRepository.findTopByPostIdAndReactionType(postId, "COMMENT");
+        Optional<Comment> comment = commentRepository.findTopByPostIdAndReactionType(
+                postId,
+                "COMMENT",
+                BEST_COMMENT_REACTION_COUNT);
         return comment.orElse(null);
     }
 }

--- a/src/main/java/com/develop_ping/union/comment/infra/CommentRepository.java
+++ b/src/main/java/com/develop_ping/union/comment/infra/CommentRepository.java
@@ -21,9 +21,11 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         LEFT JOIN reactions r ON c.id = r.target_id AND r.type = :reactionType
         WHERE c.post_id = :postId
         GROUP BY c.id
+        HAVING COUNT(r.id) >= :minLikes
         ORDER BY COUNT(r.id) DESC, c.created_at ASC
         LIMIT 1
         """, nativeQuery = true)
     Optional<Comment> findTopByPostIdAndReactionType(@Param("postId") Long postId,
-                                                     @Param("reactionType") String reactionType);
+                                                     @Param("reactionType") String reactionType,
+                                                     @Param("minLikes") long minLikes);
 }

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentBestResponse.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentBestResponse.java
@@ -7,8 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,7 +18,8 @@ public class CommentBestResponse {
     private String parentNickname;
     private ZonedDateTime createdAt;
     private long commentLikes;
-    private boolean isLiked;
+    private boolean liked;
+    private boolean deleted;
     private CommenterResponse commenter;
 
     @Builder
@@ -31,7 +30,8 @@ public class CommentBestResponse {
                                String parentNickname,
                                ZonedDateTime createdAt,
                                long commentLikes,
-                               boolean isLiked,
+                               boolean liked,
+                               boolean deleted,
                                CommenterResponse commenter) {
         this.id = id;
         this.content = content;
@@ -40,7 +40,8 @@ public class CommentBestResponse {
         this.parentNickname = parentNickname;
         this.createdAt = createdAt;
         this.commentLikes = commentLikes;
-        this.isLiked = isLiked;
+        this.liked = liked;
+        this.deleted = deleted;
         this.commenter = commenter;
     }
 
@@ -57,7 +58,8 @@ public class CommentBestResponse {
                 .parentNickname(info.getParentNickname())
                 .createdAt(info.getCreatedAt())
                 .commentLikes(info.getCommentLikes())
-                .isLiked(info.isLiked())
+                .liked(info.isLiked())
+                .deleted(info.isDeleted())
                 .commenter(CommenterResponse.from(info))
                 .build();
     }

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentDetailResponse.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentDetailResponse.java
@@ -20,7 +20,8 @@ public class CommentDetailResponse {
     private String parentNickname;
     private ZonedDateTime createdAt;
     private long commentLikes;
-    private boolean isLiked;
+    private boolean liked;
+    private boolean deleted;
     private CommenterResponse commenter;
     private List<CommentDetailResponse> children;
 
@@ -32,7 +33,8 @@ public class CommentDetailResponse {
                                  String parentNickname,
                                  ZonedDateTime createdAt,
                                  long commentLikes,
-                                 boolean isLiked,
+                                 boolean liked,
+                                 boolean deleted,
                                  CommenterResponse commenter,
                                  List<CommentDetailResponse> children) {
         this.id = id;
@@ -42,7 +44,8 @@ public class CommentDetailResponse {
         this.parentNickname = parentNickname;
         this.createdAt = createdAt;
         this.commentLikes = commentLikes;
-        this.isLiked = isLiked;
+        this.liked = liked;
+        this.deleted = deleted;
         this.commenter = commenter;
         this.children = children != null ? children : new ArrayList<>();
     }
@@ -56,7 +59,8 @@ public class CommentDetailResponse {
                 .parentNickname(info.getParentNickname())
                 .createdAt(info.getCreatedAt())
                 .commentLikes(info.getCommentLikes())
-                .isLiked(info.isLiked())
+                .liked(info.isLiked())
+                .deleted(info.isDeleted())
                 .commenter(CommenterResponse.from(info))
                 .children(new ArrayList<>())
                 .build();

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentReactionResponse.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentReactionResponse.java
@@ -10,18 +10,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentReactionResponse {
     private long commentLikes;
-    private boolean isLiked;
+    private boolean liked;
 
     @Builder
-    private CommentReactionResponse(long commentLikes, boolean isLiked) {
+    private CommentReactionResponse(long commentLikes, boolean liked) {
         this.commentLikes = commentLikes;
-        this.isLiked = isLiked;
+        this.liked = liked;
     }
 
     public static CommentReactionResponse from(CommentReactionInfo info) {
         return CommentReactionResponse.builder()
                 .commentLikes(info.getCommentLikes())
-                .isLiked(info.isLiked())
+                .liked(info.isLiked())
                 .build();
     }
 }

--- a/src/main/java/com/develop_ping/union/post/domain/PostManager.java
+++ b/src/main/java/com/develop_ping/union/post/domain/PostManager.java
@@ -6,18 +6,20 @@ import com.develop_ping.union.user.domain.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface PostManager {
     Post saveAndFlush(Post post);
     Post findById(Long id);
     Post save(Post post);
     void delete(Post post);
-    Page<Post> findByPostType(PostType postType, Pageable pageable);
-    Page<Post> findByUser(User user, Pageable pageable);
-    Page<Post> findByUserComments(User user, Pageable pageable);
+    Page<Post> findByPostType(PostType postType, Pageable pageable, List<Long> blockedUserIds);
+    Page<Post> findByUser(User user, Pageable pageable, List<Long> blockedUserIds);
+    Page<Post> findByUserComments(User user, Pageable pageable, List<Long> blockedUserIds);
     Post validatePostOwner(Long userId, Long postId);
-    Page<Post> searchByTypeAndKeyword(PostType type, String keyword, Pageable pageable);
-    Page<Post> searchByKeyword(String keyword, Pageable pageable);
-    Page<Post> findPopularPosts(Pageable pageable);
+    Page<Post> searchByTypeAndKeyword(PostType type, String keyword, Pageable pageable, List<Long> blockedUserIds);
+    Page<Post> searchByKeyword(String keyword, Pageable pageable, List<Long> blockedUserIds);
+    Page<Post> findPopularPosts(Pageable pageable, List<Long> blockedUserIds);
     long countByUserId(Long userId);
-    long countPostsByUserComments(Long userId);
+    long countPostsByUserComments(Long userId, List<Long> blockedUserIds);
 }

--- a/src/main/java/com/develop_ping/union/post/domain/dto/command/PostListCommand.java
+++ b/src/main/java/com/develop_ping/union/post/domain/dto/command/PostListCommand.java
@@ -59,11 +59,13 @@ public class PostListCommand {
                 .build();
     }
 
-    public static PostListCommand userOf(int page,
+    public static PostListCommand userOf(User user,
+                                         int page,
                                          int size,
                                          String userToken,
                                          Criterion criterion) {
         return PostListCommand.builder()
+                .user(user)
                 .page(page)
                 .size(size)
                 .userToken(userToken)

--- a/src/main/java/com/develop_ping/union/post/domain/service/PostServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/post/domain/service/PostServiceImpl.java
@@ -8,7 +8,6 @@ import com.develop_ping.union.post.domain.dto.info.*;
 import com.develop_ping.union.post.domain.entity.Post;
 import com.develop_ping.union.post.domain.entity.PostType;
 import com.develop_ping.union.reaction.domain.ReactionManager;
-import com.develop_ping.union.reaction.domain.entity.ReactionType;
 import com.develop_ping.union.user.domain.BlockUserManager;
 import com.develop_ping.union.user.domain.UserManager;
 import com.develop_ping.union.user.domain.entity.User;
@@ -130,9 +129,8 @@ public class PostServiceImpl implements PostService {
         log.info("[ CALL: PostService.getPostLikes() ] post id: {}", command.getId());
 
         long likes = reactionManager.countLikesByPost(command.getId());
-        boolean isLiked = reactionManager.existsByUserIdAndTypeAndId(
+        boolean isLiked = reactionManager.existsPostLikeByUserId(
                 command.getUser().getId(),
-                ReactionType.POST,
                 command.getId()
         );
 

--- a/src/main/java/com/develop_ping/union/post/infra/PostManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/post/infra/PostManagerImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -44,19 +46,19 @@ public class PostManagerImpl implements PostManager {
     }
 
     @Override
-    public Page<Post> findByPostType(PostType postType, Pageable pageable) {
+    public Page<Post> findByPostType(PostType postType, Pageable pageable, List<Long> blockedUserIds) {
         log.info("[ CALL: PostManager.findByPostType() ] postType: {}", postType);
-        return postRepository.findByType(postType, pageable);
+        return postRepository.findByType(postType, blockedUserIds, pageable);
     }
 
     @Override
-    public Page<Post> findByUser(User user, Pageable pageable) {
+    public Page<Post> findByUser(User user, Pageable pageable, List<Long> blockedUserIds) {
         return postRepository.findByUser(user, pageable);
     }
 
     @Override
-    public Page<Post> findByUserComments(User user, Pageable pageable) {
-        return postRepository.findPostsByUserComments(user, pageable);
+    public Page<Post> findByUserComments(User user, Pageable pageable, List<Long> blockedUserIds) {
+        return postRepository.findPostsByUserComments(user, blockedUserIds, pageable);
     }
 
     @Override
@@ -71,18 +73,25 @@ public class PostManagerImpl implements PostManager {
     }
 
     @Override
-    public Page<Post> searchByTypeAndKeyword(PostType type, String keyword, Pageable pageable) {
-        return postRepository.searchByTypeAndKeyword(type, keyword, pageable);
+    public Page<Post> searchByTypeAndKeyword(PostType type,
+                                             String keyword,
+                                             Pageable pageable,
+                                             List<Long> blockedUserIds) {
+        return postRepository.searchByTypeAndKeyword(type, keyword, blockedUserIds, pageable);
     }
 
     @Override
-    public Page<Post> searchByKeyword(String keyword, Pageable pageable) {
-        return  postRepository.searchByKeyword(keyword, pageable);
+    public Page<Post> searchByKeyword(String keyword, Pageable pageable, List<Long> blockedUserIds) {
+        return  postRepository.searchByKeyword(keyword, blockedUserIds, pageable);
     }
 
     @Override
-    public Page<Post> findPopularPosts(Pageable pageable) {
-        return postRepository.findPopularPosts(ReactionType.POST, POPULAR_POST_REACTION_COUNT, pageable);
+    public Page<Post> findPopularPosts(Pageable pageable, List<Long> blockedUserIds) {
+        return postRepository.findPopularPosts(
+                ReactionType.POST,
+                POPULAR_POST_REACTION_COUNT,
+                blockedUserIds,
+                pageable);
     }
 
     @Override
@@ -93,7 +102,7 @@ public class PostManagerImpl implements PostManager {
 
     @Override
     @Transactional(readOnly = true)
-    public long countPostsByUserComments(Long userId) {
-        return postRepository.countPostsByUserComments(userId);
+    public long countPostsByUserComments(Long userId, List<Long> blockedUserIds) {
+        return postRepository.countPostsByUserComments(userId, blockedUserIds);
     }
 }

--- a/src/main/java/com/develop_ping/union/post/infra/PostRepository.java
+++ b/src/main/java/com/develop_ping/union/post/infra/PostRepository.java
@@ -11,46 +11,75 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-    Page<Post> findByType(PostType type, Pageable pageable);
-
-    Page<Post> findByUser(User user, Pageable pageable);
-
-    @Query("SELECT DISTINCT p FROM Post p JOIN p.comments c WHERE c.user = :user")
-    Page<Post> findPostsByUserComments(@Param("user") User user, Pageable pageable);
+    @Query("""
+            SELECT p FROM Post p
+            WHERE p.type = :type
+                AND p.user.id NOT IN :blockedUserIds
+    """)
+    Page<Post> findByType(PostType type,
+                          @Param("blockedUserIds") List<Long> blockedUserIds,
+                          Pageable pageable);
 
     @Query("""
             SELECT p FROM Post p
             WHERE p.type = :type
-              AND (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')))
+                AND p.user.id NOT IN :blockedUserIds
+                AND (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                    OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')))
     """)
     Page<Post> searchByTypeAndKeyword(
             @Param("type") PostType type,
             @Param("keyword") String keyword,
+            @Param("blockedUserIds") List<Long> blockedUserIds,
             Pageable pageable);
+
+    Page<Post> findByUser(User user, Pageable pageable);
+
+    @Query("""
+            SELECT DISTINCT p FROM Post p
+            JOIN p.comments c
+            WHERE c.user = :user
+                AND p.user.id NOT IN :blockedUserIds
+    """)
+    Page<Post> findPostsByUserComments(@Param("user") User user,
+                                       @Param("blockedUserIds") List<Long> blockedUserIds,
+                                       Pageable pageable);
 
     @Query("""
             SELECT p FROM Post p
-            WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
-               OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%'))
+            WHERE p.user.id NOT IN :blockedUserIds
+                AND (LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                    OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')))
     """)
-    Page<Post> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+    Page<Post> searchByKeyword(@Param("keyword") String keyword,
+                               @Param("blockedUserIds") List<Long> blockedUserIds,
+                               Pageable pageable);
 
     @Query("""
             SELECT p FROM Post p
             JOIN Reaction r ON p.id = r.targetId
-            WHERE r.type = :reactionType
+            WHERE p.user.id NOT IN :blockedUserIds
+                AND r.type = :reactionType
             GROUP BY p.id
             HAVING COUNT(r.id) >= :minLikes
     """)
     Page<Post> findPopularPosts(@Param("reactionType") ReactionType reactionType,
                                 @Param("minLikes") long minLikes,
+                                @Param("blockedUserIds") List<Long> blockedUserIds,
                                 Pageable pageable);
 
     long countByUserId(Long userId);
 
-    @Query("SELECT COUNT(DISTINCT p) FROM Post p JOIN p.comments c WHERE c.user.id = :userId")
-    long countPostsByUserComments(@Param("userId") Long userId);
+    @Query("""
+            SELECT COUNT(DISTINCT p)
+            FROM Post p JOIN p.comments c
+            WHERE c.user.id = :userId
+                AND p.user.id NOT IN :blockedUserIds
+    """)
+    long countPostsByUserComments(@Param("userId") Long userId,
+                                  @Param("blockedUserIds") List<Long> blockedUserIds);
 }

--- a/src/main/java/com/develop_ping/union/post/presentation/PostListController.java
+++ b/src/main/java/com/develop_ping/union/post/presentation/PostListController.java
@@ -71,13 +71,14 @@ public class PostListController {
     @GetMapping("/user/{userToken}/posts")
     public Page<PostListResponse> getUserPostList(@PathVariable("userToken") String userToken,
                                                   @RequestParam(defaultValue = "0") int page,
-                                                  @RequestParam(defaultValue = "3") int size) {
+                                                  @RequestParam(defaultValue = "3") int size,
+                                                  @AuthenticationPrincipal User user) {
         log.info("[ CALL: PostListController.getUserPostList() ]");
 
         // 특정 유저 기준으로 조회
         Criterion criterion = Criterion.USER;
 
-        PostListCommand command = PostListCommand.userOf(page, size, userToken, criterion);
+        PostListCommand command = PostListCommand.userOf(user, page, size, userToken, criterion);
         Page<PostListInfo> postListInfoPage = postService.getPosts(command);
 
         return postListInfoPage.map(PostListResponse::from);
@@ -86,13 +87,14 @@ public class PostListController {
     @GetMapping("/user/{userToken}/comments")
     public Page<PostListResponse> getUserCommentedPostList(@PathVariable("userToken") String userToken,
                                                            @RequestParam(defaultValue = "0") int page,
-                                                           @RequestParam(defaultValue = "3") int size) {
+                                                           @RequestParam(defaultValue = "3") int size,
+                                                           @AuthenticationPrincipal User user) {
         log.info("[ CALL: PostListController.getUserCommentedPostList() ]");
 
         // 특정 유저가 댓글을 단 게시글 조회
         Criterion criterion = Criterion.USER_COMMENT;
 
-        PostListCommand command = PostListCommand.userOf(page, size, userToken, criterion);
+        PostListCommand command = PostListCommand.userOf(user, page, size, userToken, criterion);
         Page<PostListInfo> postListInfoPage = postService.getPosts(command);
 
         return postListInfoPage.map(PostListResponse::from);

--- a/src/main/java/com/develop_ping/union/reaction/domain/ReactionManager.java
+++ b/src/main/java/com/develop_ping/union/reaction/domain/ReactionManager.java
@@ -10,6 +10,8 @@ import java.util.List;
 public interface ReactionManager {
 
     boolean existsByUserIdAndTypeAndId(Long userId, ReactionType type, Long gatheringId);
+    boolean existsPostLikeByUserId(Long userId, Long postId);
+    boolean existsCommentLikeByUserId(Long userId, Long commentId);
 
     Long likePost(User user, Long postId);
     Long likeGathering(User user, Long gatheringId);

--- a/src/main/java/com/develop_ping/union/reaction/infra/ReactionManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/reaction/infra/ReactionManagerImpl.java
@@ -25,6 +25,18 @@ public class ReactionManagerImpl implements ReactionManager {
     }
 
     @Override
+    public boolean existsPostLikeByUserId(Long userId, Long postId) {
+        ReactionType type = ReactionType.POST;
+        return reactionRepository.existsByUserIdAndTypeAndTargetId(userId, type, postId);
+    }
+
+    @Override
+    public boolean existsCommentLikeByUserId(Long userId, Long commentId) {
+        ReactionType type = ReactionType.COMMENT;
+        return reactionRepository.existsByUserIdAndTypeAndTargetId(userId, type, commentId);
+    }
+
+    @Override
     public Long likePost(User user, Long postId) {
         ReactionType type = ReactionType.POST;
         return toggleReaction(user, postId, type);

--- a/src/main/java/com/develop_ping/union/user/domain/service/UserServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/user/domain/service/UserServiceImpl.java
@@ -161,8 +161,13 @@ public class UserServiceImpl implements UserService {
         Long targetUserId = targetUser.getId();
         log.info("target user nickname: {}", targetUser.getNickname());
 
+        List<Long> blockedUserIds = blockUserManager.findAllBlockedOrBlockingUser(command.getUser())
+                .stream()
+                .map(User::getId)
+                .toList();
+
         long postCount = postManager.countByUserId(targetUserId);
-        long commentCount = postManager.countPostsByUserComments(targetUserId);
+        long commentCount = postManager.countPostsByUserComments(targetUserId, blockedUserIds);
         long gatheringCount = partyManager.countByUserIdAndRole(targetUserId);
 
         return UserStatInfo.of(postCount, commentCount, gatheringCount);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -118,18 +118,18 @@ VALUES
 
 -- 댓글 더미 데이터
 INSERT INTO comments
-(content, post_id, user_id, parent_id, parent_nickname, created_at, updated_at)
+(content, post_id, user_id, parent_id, parent_nickname, created_at, updated_at, deleted)
 VALUES
-    ('첫 번째 게시글의 첫 번째 댓글입니다.', 1, 1, NULL, NULL, NOW(), NOW()),
-    ('첫 번째 게시글의 두 번째 댓글입니다.', 1, 2, NULL, NULL, NOW(), NOW()),
-    ('첫 번째 게시글의 첫 번째 댓글에 대한 대댓글입니다.', 1, 3, 1, 'user1nick', NOW(), NOW()),
-    ('두 번째 게시글의 첫 번째 댓글입니다.', 2, 4, NULL, NULL, NOW(), NOW()),
-    ('세 번째 게시글의 첫 번째 댓글입니다.', 3, 2, NULL, NULL, NOW(), NOW()),
-    ('네 번째 게시글의 첫 번째 댓글입니다.', 4, 5, NULL, NULL, NOW(), NOW()),
-    ('네 번째 게시글의 첫 번째 댓글에 대한 대댓글입니다.', 4, 3, 6, 'user5nick', NOW(), NOW()),
-    ('다섯 번째 게시글의 첫 번째 댓글입니다.', 5, 4, NULL, NULL, NOW(), NOW()),
-    ('여섯 번째 게시글의 첫 번째 댓글입니다.', 6, 1, NULL, NULL, NOW(), NOW()),
-    ('일곱 번째 게시글의 첫 번째 댓글입니다.', 7, 2, NULL, NULL, NOW(), NOW());
+    ('첫 번째 게시글의 첫 번째 댓글입니다.', 1, 1, NULL, NULL, NOW(), NOW(), false),
+    ('첫 번째 게시글의 두 번째 댓글입니다.', 1, 2, NULL, NULL, NOW(), NOW(), false),
+    ('첫 번째 게시글의 첫 번째 댓글에 대한 대댓글입니다.', 1, 3, 1, 'user1nick', NOW(), NOW(), false),
+    ('두 번째 게시글의 첫 번째 댓글입니다.', 2, 4, NULL, NULL, NOW(), NOW(), false),
+    ('세 번째 게시글의 첫 번째 댓글입니다.', 3, 2, NULL, NULL, NOW(), NOW(), false),
+    ('네 번째 게시글의 첫 번째 댓글입니다.', 4, 5, NULL, NULL, NOW(), NOW(), false),
+    ('네 번째 게시글의 첫 번째 댓글에 대한 대댓글입니다.', 4, 3, 6, 'user5nick', NOW(), NOW(), false),
+    ('다섯 번째 게시글의 첫 번째 댓글입니다.', 5, 4, NULL, NULL, NOW(), NOW(), false),
+    ('여섯 번째 게시글의 첫 번째 댓글입니다.', 6, 1, NULL, NULL, NOW(), NOW(), false),
+    ('일곱 번째 게시글의 첫 번째 댓글입니다.', 7, 2, NULL, NULL, NOW(), NOW(), false);
 
 -- 댓글 좋아요 더미 데이터
 INSERT INTO reactions


### PR DESCRIPTION
## ⚡️ 관련 이슈

> close #150

## 📝 작업 내용

> 게시글과 댓글에 유저 차단 기능을 적용합니다.

> 게시글
> 차단한/차단된 유저의 글이 목록에서 제외됩니다.

> 댓글
> 차단한/차단된 유저의 댓글에 `delete = true`를 설정합니다.
> 이 과정에서 논리 삭제를 이용합니다.

> 댓글 논리 삭제
> 자식이 없는 부모 댓글의 경우 목록에서 제외됩니다.
> 자식이 있는 부모 댓글의 경우 내용이 필터링 됩니다.
> 자식 댓글이 모두 삭제되어야 목록에서 제외됩니다.
> 차단한/차단된 유저가 작성한 댓글인 경우 자식 댓글 유무에 상관 없이 `delete = true`가 적용됩니다.

> DTO 변경
> `liked` 필드가 설정된 위치가 아닌 최하단에 위치하던 현상을 해결하였습니다.
> `delete` 필드가 추가되었습니다.

> 베스트 댓글 선정
> 댓글에 좋아요가 0개여도 베스트 댓글로 선정되었던 현상을 해결하였습니다.


## 🎸 기타 (선택)
>

## 💬 리뷰 요구사항(선택)

> 
