### PR TITLE
fix: 댓글 리스트 순서 보장되도록 수정

### DIFF
--- a/src/main/java/com/develop_ping/union/comment/domain/entity/Comment.java
+++ b/src/main/java/com/develop_ping/union/comment/domain/entity/Comment.java
@@ -41,7 +41,6 @@ public class Comment extends AuditingFields {
     private String parentNickname;
 
     @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @OrderBy("createdAt ASC")
     private List<Comment> children = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentListResponse.java
+++ b/src/main/java/com/develop_ping/union/comment/presentation/dto/response/CommentListResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -26,7 +27,12 @@ public class CommentListResponse {
         // commentInfo -> CommentDetailResponse
         Map<Long, CommentDetailResponse> responseMap = infos.stream()
                 .map(CommentDetailResponse::from)
-                .collect(Collectors.toMap(CommentDetailResponse::getId, response -> response));
+                .collect(Collectors.toMap(
+                        CommentDetailResponse::getId,
+                        response -> response,
+                        (existing, replacement) -> existing,
+                        LinkedHashMap::new  // LinkedHashMap으로 순서 보장
+                ));
 
         // 부모 댓글에 자식 댓글 추가
         responseMap.values().forEach(response -> {


### PR DESCRIPTION
## ⚡️ 관련 이슈

> *

## 📝 작업 내용

> LinkedHashMap을 사용하여 댓글 리스트의 순서를 보장

## 🎸 기타 (선택)
> 

## 💬 리뷰 요구사항(선택)

> 
