### PR TITLE
Fix: notification read 기능 중 response에 게시판 종류 필드 추가

### DIFF
--- a/src/main/java/com/develop_ping/union/notification/domain/dto/NotificationInfo.java
+++ b/src/main/java/com/develop_ping/union/notification/domain/dto/NotificationInfo.java
@@ -2,6 +2,7 @@ package com.develop_ping.union.notification.domain.dto;
 
 import com.develop_ping.union.notification.domain.NotiType;
 import com.develop_ping.union.notification.domain.entity.Notification;
+import com.develop_ping.union.post.domain.entity.PostType;
 import com.develop_ping.union.user.domain.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +21,7 @@ public class NotificationInfo {
     private Long id;
     private NotiType type;
     private Long typeId;
+    private PostType postType;
     private Long creatorTypeId;
     private Long attendeeTypeId;
     private ZonedDateTime createdAt;

--- a/src/main/java/com/develop_ping/union/notification/domain/dto/NotificationListInfo.java
+++ b/src/main/java/com/develop_ping/union/notification/domain/dto/NotificationListInfo.java
@@ -25,6 +25,7 @@ public class NotificationListInfo {
                     .id(notification.getId())
                     .type(notification.getType())
                     .typeId(notification.getTypeId())
+                    .postType(notification.getPostType())
                     .nickname(notification.getNickname())
                     .title(notification.getTitle())
                     .content(notification.getContent())

--- a/src/main/java/com/develop_ping/union/notification/infra/dto/NotificationReadForService.java
+++ b/src/main/java/com/develop_ping/union/notification/infra/dto/NotificationReadForService.java
@@ -1,6 +1,7 @@
 package com.develop_ping.union.notification.infra.dto;
 
 import com.develop_ping.union.notification.domain.NotiType;
+import com.develop_ping.union.post.domain.entity.PostType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,4 +22,5 @@ public class NotificationReadForService {
     private String content;
     private ZonedDateTime createdAt;
     private Boolean isRead;
+    private PostType postType;
 }

--- a/src/main/java/com/develop_ping/union/notification/presentation/dto/response/NotificationReadForResponse.java
+++ b/src/main/java/com/develop_ping/union/notification/presentation/dto/response/NotificationReadForResponse.java
@@ -1,6 +1,7 @@
 package com.develop_ping.union.notification.presentation.dto.response;
 
 import com.develop_ping.union.notification.domain.NotiType;
+import com.develop_ping.union.post.domain.entity.PostType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,4 +22,5 @@ public class NotificationReadForResponse {
     private String content;
     private ZonedDateTime createdAt;
     private Boolean isRead;
+    private PostType postType;
 }

--- a/src/main/java/com/develop_ping/union/notification/presentation/dto/response/NotificationReadForResponseList.java
+++ b/src/main/java/com/develop_ping/union/notification/presentation/dto/response/NotificationReadForResponseList.java
@@ -25,6 +25,7 @@ public class NotificationReadForResponseList {
                             .id(notify.getId())
                             .type(notify.getType())
                             .typeId(notify.getTypeId())
+                            .postType(notify.getPostType())
                             .nickname(notify.getNickname())
                             .title(notify.getTitle())
                             .content(notify.getContent())

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -70,7 +70,7 @@ VALUES
 INSERT INTO posts
     (title, content, type, views, created_at, updated_at, user_id, thumbnail)
 VALUES
-    ('첫 번째 게시글', '첫 번째 게시글 내용입니다.', 'FREE', 10, NOW(), NOW(), 1,
+    ('첫 번째 게시글', '첫 번째 게시글 내용입니다.', 'MARKET', 10, NOW(), NOW(), 1,
      'https://union-image-bucket.s3.ap-northeast-2.amazonaws.com/userToken/44009c26-13fc-4912-a3db-7cac644e39c5.png'),
     ('두 번째 게시글', '두 번째 게시글 내용입니다.', 'MARKET', 20, NOW(), NOW(), 2,
      'https://union-image-bucket.s3.ap-northeast-2.amazonaws.com/userToken/44009c26-13fc-4912-a3db-7cac644e39c5.png'),


### PR DESCRIPTION
## ⚡️ 관련 이슈

close #165 

## 📝 작업 내용
- response 데이터에 postType 추가
- sql 변경
- data.sql 더미데이터 변경

## 🎸 기타 (선택)
- gathering의 경우, postType이 의미가 없기 때문에 FREE로 통일

## 💬 리뷰 요구사항(선택)
없습니다
