### PR TITLE
fix: notification 중 isRead 변경 api 작동 방식 수정

### DIFF
--- a/src/main/java/com/develop_ping/union/notification/domain/NotificationManager.java
+++ b/src/main/java/com/develop_ping/union/notification/domain/NotificationManager.java
@@ -10,5 +10,6 @@ import java.util.List;
 public interface NotificationManager {
     Notification save(Notification notification);
     List<NotificationReadForService> findAllOrderByDate(Long page, Long size, User user);
-    void updateAll(Long page, Long size, User user);
+    Notification updateIsRead(Long id, User user);
+    Boolean isExistNotification(Long id);
 }

--- a/src/main/java/com/develop_ping/union/notification/domain/dto/NotificationCommand.java
+++ b/src/main/java/com/develop_ping/union/notification/domain/dto/NotificationCommand.java
@@ -1,6 +1,7 @@
 package com.develop_ping.union.notification.domain.dto;
 
 import com.develop_ping.union.notification.domain.NotiType;
+import com.develop_ping.union.notification.domain.entity.Notification;
 import com.develop_ping.union.notification.presentation.dto.request.NotificationCreationForPostRequest;
 import com.develop_ping.union.user.domain.entity.User;
 import lombok.AllArgsConstructor;
@@ -21,11 +22,19 @@ public class NotificationCommand {
     private Long page;
     private Long size;
     private User user;
+    private Long id;
 
     public static NotificationCommand readOf(Long page, Long size, User user){
         return NotificationCommand.builder()
                 .page(page)
                 .size(size)
+                .user(user)
+                .build();
+    }
+
+    public static NotificationCommand updateOf(Long id, User user){
+        return NotificationCommand.builder()
+                .id(id)
                 .user(user)
                 .build();
     }

--- a/src/main/java/com/develop_ping/union/notification/domain/dto/NotificationCommand.java
+++ b/src/main/java/com/develop_ping/union/notification/domain/dto/NotificationCommand.java
@@ -31,12 +31,4 @@ public class NotificationCommand {
                 .user(user)
                 .build();
     }
-
-    public static NotificationCommand updateOf(Long id, User user){
-        return NotificationCommand.builder()
-                .id(id)
-                .user(user)
-                .build();
-    }
-
 }

--- a/src/main/java/com/develop_ping/union/notification/domain/entity/Notification.java
+++ b/src/main/java/com/develop_ping/union/notification/domain/entity/Notification.java
@@ -5,13 +5,17 @@ import com.develop_ping.union.common.base.AuditingFields;
 import com.develop_ping.union.notification.domain.NotiType;
 import com.develop_ping.union.user.domain.entity.User;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.aspectj.weaver.ast.Not;
 
 @Entity
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "notifications")
 public class Notification extends AuditingFields {
     @Id
@@ -26,10 +30,10 @@ public class Notification extends AuditingFields {
     private Long attendeeTypeId;
     @Column(nullable = false)
     private Boolean isRead;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "creator_id")
     private User creator;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "attendee_id")
     private User attendee;
 

--- a/src/main/java/com/develop_ping/union/notification/domain/service/NotificationService.java
+++ b/src/main/java/com/develop_ping/union/notification/domain/service/NotificationService.java
@@ -10,5 +10,5 @@ public interface NotificationService {
     NotificationInfo createNotificationForComment(NotificationCommand command);
     NotificationInfo createNotificationForGathering(NotificationCommand command);
     NotificationListInfo readNotification(NotificationCommand command);
-    void updateNotification(NotificationCommand command);
+    NotificationInfo updateNotification(NotificationCommand command);
 }

--- a/src/main/java/com/develop_ping/union/notification/domain/service/NotificationServiceImpl.java
+++ b/src/main/java/com/develop_ping/union/notification/domain/service/NotificationServiceImpl.java
@@ -85,9 +85,14 @@ public class NotificationServiceImpl implements NotificationService{
 
     @Override
     @Transactional
-    public void updateNotification(NotificationCommand command) {
+    public NotificationInfo updateNotification(NotificationCommand command) {
         log.info("[ CALL: NotificationService.updateNotification() ] user id: {}", command.getUser().getId());
 
-        notificationManager.updateAll(command.getPage(), command.getSize(), command.getUser());
+        if (!notificationManager.isExistNotification(command.getId()))
+            throw new IllegalArgumentException("id와 일치하는 notification 없음");
+
+        Notification notification = notificationManager.updateIsRead(command.getId(), command.getUser());
+
+        return NotificationInfo.of(notification);
     }
 }

--- a/src/main/java/com/develop_ping/union/notification/infra/NotificationManagerImpl.java
+++ b/src/main/java/com/develop_ping/union/notification/infra/NotificationManagerImpl.java
@@ -27,10 +27,15 @@ public class NotificationManagerImpl implements NotificationManager {
     }
 
     @Override
-    public void updateAll(Long page, Long size, User user) {
-        log.info("[ CALL: NotificationManager.updateAll() ] user id: {}", user.getId());
-        notificationRepository.updateAll(page, size, user);
+    public Notification updateIsRead(Long id, User user) {
+        log.info("[ CALL: NotificationManager.updateIsRead() ] user id: {}", user.getId());
+        return notificationRepository.updateIsRead(id, user);
     }
 
+    @Override
+    public Boolean isExistNotification(Long id) {
+        log.info("[ CALL: NotificationManager.isExistNotification() ] notification id: {}", id);
+        return notificationRepository.existsById(id);
+    }
 }
 

--- a/src/main/java/com/develop_ping/union/notification/infra/NotificationRepository.java
+++ b/src/main/java/com/develop_ping/union/notification/infra/NotificationRepository.java
@@ -8,5 +8,4 @@ import java.util.List;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
-
 }

--- a/src/main/java/com/develop_ping/union/notification/infra/NotificationRepositoryCustom.java
+++ b/src/main/java/com/develop_ping/union/notification/infra/NotificationRepositoryCustom.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface NotificationRepositoryCustom {
     List<NotificationReadForService> findAllOrderById(Long page, Long size, User user);
-    void updateAll(Long page, Long size, User user);
+    Notification updateIsRead(Long id, User user);
 }

--- a/src/main/java/com/develop_ping/union/notification/infra/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/com/develop_ping/union/notification/infra/NotificationRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.develop_ping.union.notification.infra;
 
 import com.develop_ping.union.notification.domain.NotiType;
+import com.develop_ping.union.notification.domain.entity.Notification;
 import com.develop_ping.union.notification.infra.dto.NotificationReadForService;
 import com.develop_ping.union.post.domain.entity.PostType;
 import com.develop_ping.union.user.domain.entity.User;
@@ -102,27 +103,20 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
     }
 
     @Override
-    public void updateAll(Long page, Long size, User user) {
+    public Notification updateIsRead(Long id, User user) {
         // update query
         String queryForUpdate = """
                 UPDATE notifications
                 SET is_read = true
-                WHERE id IN (
-                    SELECT temp.id FROM (
-                        SELECT notifications.id
-                        FROM notifications
-                        WHERE notifications.creator_id = :userId
-                        ORDER BY notifications.id DESC
-                        LIMIT :size OFFSET :offset
-                    ) AS temp
-                );
+                WHERE 1=1
+                AND id = :id;
                 """;
 
         em.createNativeQuery(queryForUpdate)
-                .setParameter("userId", user.getId())
-                .setParameter("size", size)
-                .setParameter("offset", page * size)
+                .setParameter("id", id)
                 .executeUpdate();
+
+        return em.find(Notification.class, id);
     }
 
 

--- a/src/main/java/com/develop_ping/union/notification/presentation/NotificationController.java
+++ b/src/main/java/com/develop_ping/union/notification/presentation/NotificationController.java
@@ -7,6 +7,7 @@ import com.develop_ping.union.notification.domain.service.NotificationService;
 import com.develop_ping.union.notification.presentation.dto.request.NotificationCreationForCommentRequest;
 import com.develop_ping.union.notification.presentation.dto.request.NotificationCreationForGatheringRequest;
 import com.develop_ping.union.notification.presentation.dto.request.NotificationCreationForPostRequest;
+import com.develop_ping.union.notification.presentation.dto.request.NotificationUpdateIsReadRequest;
 import com.develop_ping.union.notification.presentation.dto.response.*;
 import com.develop_ping.union.user.domain.entity.User;
 import jakarta.validation.Valid;
@@ -16,8 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.ResourceBundle;
 
 @RestController
 @RequestMapping("/notification")
@@ -63,11 +62,12 @@ public class NotificationController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
     @PutMapping("/read")
-    public ResponseEntity<HttpStatus> createNotificationIsRead(@RequestParam("page") Long page, @RequestParam("size") Long size, @AuthenticationPrincipal User user){
-        log.info("[ CALL: NotificationController.createNotificationIsRead() ] user id: {}", user.getId());
-        NotificationCommand command = NotificationCommand.readOf(page, size, user);
-        notificationService.updateNotification(command);
+    public ResponseEntity<NotificationUpdateIsReadResponse> updateNotificationIsRead(@RequestBody @Valid NotificationUpdateIsReadRequest request, @AuthenticationPrincipal User user){
+        log.info("[ CALL: NotificationController.updateNotificationIsRead() ] user id: {}", user.getId());
+        NotificationCommand command = request.toCommand(user);
+        NotificationInfo info = notificationService.updateNotification(command);
+        NotificationUpdateIsReadResponse response = NotificationUpdateIsReadResponse.from(info);
 
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/develop_ping/union/notification/presentation/dto/request/NotificationUpdateIsReadRequest.java
+++ b/src/main/java/com/develop_ping/union/notification/presentation/dto/request/NotificationUpdateIsReadRequest.java
@@ -1,0 +1,19 @@
+package com.develop_ping.union.notification.presentation.dto.request;
+
+import com.develop_ping.union.notification.domain.dto.NotificationCommand;
+import com.develop_ping.union.user.domain.entity.User;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class NotificationUpdateIsReadRequest {
+    private Long id;
+    public NotificationCommand toCommand(User user){
+        return NotificationCommand.builder()
+                .user(user)
+                .id(this.id)
+                .build();
+    }
+}

--- a/src/main/java/com/develop_ping/union/notification/presentation/dto/response/NotificationUpdateIsReadResponse.java
+++ b/src/main/java/com/develop_ping/union/notification/presentation/dto/response/NotificationUpdateIsReadResponse.java
@@ -1,0 +1,19 @@
+package com.develop_ping.union.notification.presentation.dto.response;
+
+import com.develop_ping.union.notification.domain.dto.NotificationInfo;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class NotificationUpdateIsReadResponse {
+    private Long id;
+    private Boolean isRead;
+
+    public static NotificationUpdateIsReadResponse from(NotificationInfo notificationInfo){
+        return NotificationUpdateIsReadResponse.builder()
+                .id(notificationInfo.getId())
+                .isRead(notificationInfo.getIsRead())
+                .build();
+    }
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈

close #167 

## 📝 작업 내용

- api 문서 중 "알림창 읽음 여부 create" 항목 전체 수정
- request, respond 형식 수정
- update sql 수정
- id 검증 로직 추가
- 테스트 진행

